### PR TITLE
chore(ci): stale API docs E2E shard path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           - scope: api-mcp
             paths: tests/e2e/src/app/api
           - scope: public-web
-            paths: tests/e2e/src/app/test.ts tests/e2e/src/app/api-docs tests/e2e/src/app/bus tests/e2e/src/app/bus-map tests/e2e/src/app/courses tests/e2e/src/app/guides tests/e2e/src/app/mobile-app tests/e2e/src/app/privacy tests/e2e/src/app/sections tests/e2e/src/app/signin tests/e2e/src/app/teachers tests/e2e/src/app/terms tests/e2e/src/app/u tests/e2e/src/app/welcome
+            paths: tests/e2e/src/app/test.ts tests/e2e/src/app/bus tests/e2e/src/app/bus-map tests/e2e/src/app/courses tests/e2e/src/app/guides tests/e2e/src/app/mobile-app tests/e2e/src/app/privacy tests/e2e/src/app/sections tests/e2e/src/app/signin tests/e2e/src/app/teachers tests/e2e/src/app/terms tests/e2e/src/app/u tests/e2e/src/app/welcome
           - scope: signed-in
             paths: tests/e2e/src/app/dashboard tests/e2e/src/app/e2e tests/e2e/src/app/oauth tests/e2e/src/app/settings
           - scope: admin-comments


### PR DESCRIPTION
## Summary

- removes the obsolete `tests/e2e/src/app/api-docs` path from the public-web CI shard
- keeps API docs E2E coverage under the existing `tests/e2e/src/app/api` shard, where `tests/e2e/src/app/api/docs` now lives
- confirmed current CI workflow files no longer reference MinIO/S3 setup; Worker E2E uses Wrangler local `R2_UPLOADS` instead

## Validation

- `bun --silent run tools/dev/check.ts e2e`
- workflow YAML parse check with `yaml`
- `git diff --check`

## Notes

GitHub Actions on this PR should provide the final workflow validation.