### PR TITLE
chore(ci): MinIO workflow setup

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -7,7 +7,7 @@ CI/CD pipelines.
 | Workflow | Trigger | Jobs |
 |----------|---------|------|
 | CI | push/PR to any branch | Default verification, Worker E2E artifact build, E2E shards |
-| DB-backed Bun job | workflow_call | Reusable Postgres + MinIO Bun job |
+| DB-backed Bun job | workflow_call | Reusable Postgres-backed Bun job |
 | E2E Snapshot Artifacts | push except preview branch, manual | Snapshot capture, artifact upload, screenshot preview publishing, commit comment |
 | Copilot Setup Steps | manual or setup workflow changes | Copilot bootstrap validation |
 | Release | push to main | Semantic release |
@@ -20,7 +20,7 @@ Keep Bun versions aligned with:
 ## Rules
 
 - Use repo's `bun`-based commands; do not add Node setup steps
-- Workflows that exercise app code should provision their own Postgres and MinIO services and set `DATABASE_URL`, `S3_BUCKET`, `AWS_REGION`, `AWS_DEFAULT_REGION`, `AWS_ENDPOINT_URL_S3`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` explicitly.
+- Workflows that exercise app code should provision their own Postgres service and set `DATABASE_URL` explicitly. Upload storage uses Cloudflare R2 bindings in Worker flows; do not add MinIO/S3 emulation to CI unless a test explicitly covers object storage behavior.
 - Production deploy is owned by Cloudflare's Git integration; do not add repo-managed deploy jobs.
 - Docker is only for local infra, CI service containers, and the static loader image; do not add app-serving Docker jobs.
 - Never commit secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     uses: ./.github/workflows/db-backed-bun-job.yml
     with:
       database-name: life_ustc_ci
-      minio-bucket: life-ustc-ci
       jwt-secret: ci-check-secret-0123456789abcdef0123456789abcdef
       auth-secret: ci-check-secret-0123456789abcdef0123456789abcdef
       job-command: bun run verify
@@ -27,7 +26,6 @@ jobs:
     uses: ./.github/workflows/db-backed-bun-job.yml
     with:
       database-name: life_ustc_e2e
-      minio-bucket: life-ustc-e2e
       jwt-secret: e2e-ci-secret
       webhook-secret: e2e-ci-secret
       auth-secret: e2e-ci-secret
@@ -60,7 +58,6 @@ jobs:
     uses: ./.github/workflows/db-backed-bun-job.yml
     with:
       database-name: life_ustc_e2e
-      minio-bucket: life-ustc-e2e
       install-playwright: true
       jwt-secret: e2e-ci-secret
       webhook-secret: e2e-ci-secret

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -46,46 +46,10 @@ jobs:
             echo "JWT_SECRET=copilot-local-secret"
             echo "WEBHOOK_SECRET=copilot-local-secret"
             echo "AUTH_SECRET=copilot-local-secret"
-            echo "S3_BUCKET=life-ustc-copilot"
-            echo "AWS_REGION=us-east-1"
-            echo "AWS_DEFAULT_REGION=us-east-1"
-            echo "AWS_ENDPOINT_URL_S3=http://127.0.0.1:9000"
-            echo "AWS_ACCESS_KEY_ID=minioadmin"
-            echo "AWS_SECRET_ACCESS_KEY=minioadmin"
           } >> "$GITHUB_ENV"
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun-env
-
-      - name: Start MinIO service
-        shell: bash
-        run: |
-          docker run -d --name minio \
-            -p 9000:9000 \
-            -e MINIO_ROOT_USER=minioadmin \
-            -e MINIO_ROOT_PASSWORD=minioadmin \
-            -e MINIO_API_CORS_ALLOW_ORIGIN=http://127.0.0.1:3000 \
-            minio/minio:latest \
-            server /data --console-address ":9001"
-
-          for _ in $(seq 1 60); do
-            if curl --noproxy "*" -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
-              break
-            fi
-            sleep 1
-          done
-
-          if ! curl --noproxy "*" -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
-            echo "MinIO failed to become ready" >&2
-            docker logs minio >&2 || true
-            exit 1
-          fi
-
-      - name: Provision MinIO bucket
-        shell: bash
-        run: |
-          docker exec minio mc alias set local http://127.0.0.1:9000 "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"
-          docker exec minio mc mb --ignore-existing "local/$S3_BUCKET"
 
       - name: Prepare database and generated artifacts
         shell: bash

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -6,9 +6,6 @@ on:
       database-name:
         required: true
         type: string
-      minio-bucket:
-        required: true
-        type: string
       job-command:
         required: true
         type: string
@@ -98,12 +95,6 @@ jobs:
         run: |
           {
             echo "DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/${{ inputs.database-name }}"
-            echo "S3_BUCKET=${{ inputs.minio-bucket }}"
-            echo "AWS_REGION=us-east-1"
-            echo "AWS_DEFAULT_REGION=us-east-1"
-            echo "AWS_ENDPOINT_URL_S3=http://127.0.0.1:9000"
-            echo "AWS_ACCESS_KEY_ID=minioadmin"
-            echo "AWS_SECRET_ACCESS_KEY=minioadmin"
             if [ -n "${{ inputs.jwt-secret }}" ]; then
               echo "JWT_SECRET=${{ inputs.jwt-secret }}"
             fi
@@ -118,36 +109,6 @@ jobs:
             fi
           } >> "$GITHUB_ENV"
 
-      - name: Start MinIO service
-        shell: bash
-        run: |
-          docker run -d --name minio \
-            -p 9000:9000 \
-            -e MINIO_ROOT_USER=minioadmin \
-            -e MINIO_ROOT_PASSWORD=minioadmin \
-            -e MINIO_API_CORS_ALLOW_ORIGIN=http://127.0.0.1:3000 \
-            minio/minio:latest \
-            server /data --console-address ":9001"
-
-          for _ in $(seq 1 60); do
-            if curl --noproxy "*" -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
-              break
-            fi
-            sleep 1
-          done
-
-          if ! curl --noproxy "*" -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
-            echo "MinIO failed to become ready" >&2
-            docker logs minio >&2 || true
-            exit 1
-          fi
-
-      - name: Provision MinIO bucket
-        shell: bash
-        run: |
-          docker exec minio mc alias set local http://127.0.0.1:9000 "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"
-          docker exec minio mc mb --ignore-existing "local/$S3_BUCKET"
-
       - name: Setup workspace
         uses: ./.github/actions/setup-bun-env
         with:
@@ -161,7 +122,7 @@ jobs:
 
       - name: Download artifact
         if: ${{ inputs.download-artifact-name != '' }}
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.download-artifact-name }}
           path: ${{ inputs.download-artifact-path }}

--- a/.github/workflows/e2e-snapshot-artifacts.yml
+++ b/.github/workflows/e2e-snapshot-artifacts.yml
@@ -60,12 +60,6 @@ jobs:
       WEBHOOK_SECRET: e2e-snapshot-ci-secret
       AUTH_SECRET: e2e-snapshot-ci-secret
       NO_PROXY: 127.0.0.1,localhost,::1
-      S3_BUCKET: life-ustc-e2e-snapshots
-      AWS_REGION: us-east-1
-      AWS_DEFAULT_REGION: us-east-1
-      AWS_ENDPOINT_URL_S3: http://127.0.0.1:9000
-      AWS_ACCESS_KEY_ID: minioadmin
-      AWS_SECRET_ACCESS_KEY: minioadmin
 
     steps:
       - name: Checkout code
@@ -78,36 +72,6 @@ jobs:
         uses: ./.github/actions/setup-bun-env
         with:
           install-playwright: "true"
-
-      - name: Start MinIO service
-        shell: bash
-        run: |
-          docker run -d --name minio \
-            -p 9000:9000 \
-            -e MINIO_ROOT_USER=minioadmin \
-            -e MINIO_ROOT_PASSWORD=minioadmin \
-            -e MINIO_API_CORS_ALLOW_ORIGIN=http://127.0.0.1:3000 \
-            minio/minio:latest \
-            server /data --console-address ":9001"
-
-          for _ in $(seq 1 60); do
-            if curl --noproxy "*" -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
-              break
-            fi
-            sleep 1
-          done
-
-          if ! curl --noproxy "*" -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
-            echo "MinIO failed to become ready" >&2
-            docker logs minio >&2 || true
-            exit 1
-          fi
-
-      - name: Provision MinIO bucket
-        shell: bash
-        run: |
-          docker exec minio mc alias set local http://127.0.0.1:9000 "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"
-          docker exec minio mc mb --ignore-existing "local/$S3_BUCKET"
 
       - name: Generate Prisma client
         shell: bash


### PR DESCRIPTION
## Summary
- remove MinIO/S3 emulation from CI, Copilot setup, and E2E snapshot workflows
- remove the reusable workflow minio-bucket input
- bump actions/download-artifact from v6 to v8 while keeping upload-artifact on v7

## Verification
- bun --silent run verify
- workflow YAML parse check via bun/yaml
- rg confirmed no MinIO/S3 emulation references remain in .github/workflows