### PR TITLE
fix(api): calendar feed tokens from API observability

### DIFF
--- a/src/lib/log/api-observability-path.ts
+++ b/src/lib/log/api-observability-path.ts
@@ -2,6 +2,7 @@ const UUID_SEGMENT =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const NUMERIC_SEGMENT = /^\d+$/;
 const OPAQUE_ID_SEGMENT = /^(?=.*\d)[A-Za-z0-9_-]{16,}$/;
+const CALENDAR_FEED_TOKEN_SEPARATOR = /:|%3a/i;
 const OBSERVABILITY_PATHS = new Set(["/api/metrics"]);
 
 export function shouldObserveApiPath(pathname: string) {
@@ -11,7 +12,15 @@ export function shouldObserveApiPath(pathname: string) {
 export function normalizeApiRoutePath(pathname: string) {
   return pathname
     .split("/")
-    .map((segment) => {
+    .map((segment, index, segments) => {
+      if (
+        CALENDAR_FEED_TOKEN_SEPARATOR.test(segment) &&
+        segments[index - 2] === "api" &&
+        segments[index - 1] === "users" &&
+        segments[index + 1] === "calendar.ics"
+      ) {
+        return ":id";
+      }
       if (NUMERIC_SEGMENT.test(segment)) return ":id";
       if (UUID_SEGMENT.test(segment)) return ":id";
       if (OPAQUE_ID_SEGMENT.test(segment)) return ":id";

--- a/tests/unit/api-observability.test.ts
+++ b/tests/unit/api-observability.test.ts
@@ -32,6 +32,20 @@ describe("api observability", () => {
     );
   });
 
+  it("redacts calendar feed path tokens", () => {
+    const normalized = normalizeApiRoutePath(
+      "/api/users/user-1:feed-token-0123456789/calendar.ics",
+    );
+    const encodedSeparator = normalizeApiRoutePath(
+      "/api/users/user-1%3Afeed-token-0123456789/calendar.ics",
+    );
+
+    expect(normalized).toBe("/api/users/:id/calendar.ics");
+    expect(encodedSeparator).toBe("/api/users/:id/calendar.ics");
+    expect(normalized).not.toContain("feed-token-0123456789");
+    expect(encodedSeparator).not.toContain("feed-token-0123456789");
+  });
+
   it("records safe request-start logs and metrics", () => {
     const info = vi.spyOn(console, "info").mockImplementation(() => {});
 


### PR DESCRIPTION
## Goal

Stop calendar feed path tokens from appearing in normalized API observability labels and logs. Closes #178.

## Changed Surfaces

- API observability route normalization for `/api/users/{userId}:{token}/calendar.ics` paths.
- Unit coverage for raw `:` and encoded `%3A` calendar feed separators.

## Evidence

- Focused regression: `bun run test -- tests/unit/api-observability.test.ts`.
- Focused formatting/lint: `bunx biome check src/lib/log/api-observability-path.ts tests/unit/api-observability.test.ts`.
- Whitespace sanity: `git diff --check origin/main...HEAD`.
- Default repo gate: `DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev" bun run verify`.

## Docs / Contracts

No product, REST, MCP, OpenAPI, Prisma, i18n, or user-facing contract changed. This is internal observability label normalization and privacy hardening.

## Risk Areas

Low. The new redaction only applies to the exact calendar feed path shape under `/api/users/*/calendar.ics`; other API routes keep the existing numeric/UUID/opaque-id normalization.

## Skipped / Notes

A first plain `bun run verify` in this separate worktree failed before typechecking because the worktree had no local `.env`, so Prisma could not resolve `DATABASE_URL`. Rerunning with the documented local dev `DATABASE_URL` passed.

## Cleanup

`git status -sb` was clean before push; no scratch artifacts or generated files were left behind.
