### PR TITLE
feat(test): AST readers for source contract checks

### DIFF
--- a/tests/unit/mcp-tool-registrations.test.ts
+++ b/tests/unit/mcp-tool-registrations.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { getRegisteredMcpToolNames } from "../../tools/shared/mcp-tool-registrations";
+
+describe("MCP tool registration parser", () => {
+  it("collects static registerTool names from AST call expressions", () => {
+    const source = `
+      server.registerTool("search_courses", {}, searchCoursesTool);
+      registerTool(\`get_course_by_jw_id\`, {}, getCourseTool);
+      server.registerTool(toolName, {}, dynamicTool);
+      // server.registerTool("commented_out", {}, noop);
+      const text = 'server.registerTool("string_only", {}, noop)';
+    `;
+
+    expect(getRegisteredMcpToolNames(source)).toEqual([
+      "search_courses",
+      "get_course_by_jw_id",
+    ]);
+  });
+});

--- a/tests/unit/route-exports.test.ts
+++ b/tests/unit/route-exports.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   getExportedRouteMethods,
+  getRouteExport,
   getRouteExportKind,
   HTTP_METHODS,
 } from "../../tools/shared/route-exports";
@@ -28,6 +29,9 @@ describe("route export parser", () => {
     expect(getRouteExportKind(source, "GET")).toBe("function");
     expect(getRouteExportKind(source, "POST")).toBe("const");
     expect(getRouteExportKind(source, "OPTIONS")).toBe("destructured");
+    expect(getRouteExport(source, "OPTIONS")?.initializer?.getText()).toBe(
+      "handlers",
+    );
     expect(getExportedRouteMethods(source)).toEqual([
       "GET",
       "POST",
@@ -45,5 +49,25 @@ describe("route export parser", () => {
     `;
 
     expect(getExportedRouteMethods(source)).toEqual([]);
+  });
+
+  it("returns the AST node that owns route export JSDoc", () => {
+    const source = `
+      /**
+       * List things.
+       * @response thingsResponseSchema
+       */
+      export const GET = svelteRequestHandler(observedApiRoute(getThings));
+    `;
+
+    const routeExport = getRouteExport(source, "GET");
+
+    expect(routeExport?.kind).toBe("const");
+    expect(routeExport?.node.getText(routeExport.sourceFile)).toContain(
+      "export const GET",
+    );
+    expect(routeExport?.initializer?.getText(routeExport.sourceFile)).toBe(
+      "svelteRequestHandler(observedApiRoute(getThings))",
+    );
   });
 });

--- a/tools/build/openapi/generate-spec.ts
+++ b/tools/build/openapi/generate-spec.ts
@@ -8,15 +8,16 @@
 import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
+import * as ts from "typescript";
 import { z } from "zod";
 import { createDocument } from "zod-openapi";
 import * as requestSchemas from "../../../src/lib/api/schemas/request-schemas";
 import * as responseSchemas from "../../../src/lib/api/schemas/response-schemas";
 import { OPENAPI_SPEC_RELATIVE_PATH } from "../../../src/lib/openapi/spec";
 import {
-  getRouteExportKind,
+  getRouteExport,
   HTTP_METHODS,
-  type RouteExportKind,
+  type RouteExport,
 } from "../../shared/route-exports";
 import { buildScenarioOpenApiExamples } from "./scenario-examples";
 
@@ -147,97 +148,158 @@ type ContractDoc = {
   >;
 };
 
-function extractJsDocAnnotations(
-  source: string,
-  httpMethod: string,
-  exportKind: RouteExportKind,
-): HandlerAnnotations | null {
-  const exportPattern =
-    exportKind === "destructured"
-      ? new RegExp(
-          `export\\s+const\\s*\\{(?=[^}]*\\b${httpMethod}\\b)[^}]*\\}\\s*=`,
-          "s",
-        )
-      : new RegExp(
-          exportKind === "const"
-            ? `export\\s+const\\s+${httpMethod}\\b(?:\\s*:[^=]+)?\\s*=`
-            : `export\\s+(?:async\\s+)?function\\s+${httpMethod}\\b`,
-        );
+function jsDocCommentText(
+  comment: string | ts.NodeArray<ts.JSDocComment> | undefined,
+) {
+  if (!comment) {
+    return "";
+  }
+  if (typeof comment === "string") {
+    return comment;
+  }
+  return comment.map((part) => part.getText()).join("");
+}
 
-  const match = exportPattern.exec(source);
-  const annotations = match ? parseJsDocBefore(source, match.index) : null;
-  if (annotations) return annotations;
+function getNodeJsDoc(node: ts.Node): ts.JSDoc | null {
+  const jsDocs = ts.getJSDocCommentsAndTags(node).filter(ts.isJSDoc);
+  return jsDocs.at(-1) ?? null;
+}
 
-  const wrappedMatch = new RegExp(
-    `export\\s+const\\s+${httpMethod}\\s*=\\s*observedApiRoute\\s*\\(\\s*(\\w+)\\s*\\)`,
-  ).exec(source);
-  if (!wrappedMatch) return null;
+function firstTagValue(tag: ts.JSDocTag) {
+  const value = jsDocCommentText(tag.comment).trim();
+  return value.split(/\s+/, 1)[0] ?? "";
+}
 
-  const handlerName = wrappedMatch[1];
-  const handlerPattern = new RegExp(
-    `(?:async\\s+)?function\\s+${handlerName}\\b`,
+function isDigits(value: string) {
+  return (
+    value.length > 0 && [...value].every((char) => char >= "0" && char <= "9")
   );
-  const handlerMatch = handlerPattern.exec(source);
-  if (!handlerMatch) return null;
-
-  return parseJsDocBefore(source, handlerMatch.index);
 }
 
-function parseJsDocBefore(
-  source: string,
-  declarationIndex: number,
-): HandlerAnnotations | null {
-  const prefix = source.slice(0, declarationIndex);
-  const commentStart = prefix.lastIndexOf("/**");
-  if (commentStart === -1) return null;
+function parseResponseTagValue(value: string) {
+  if (!value) {
+    return null;
+  }
 
-  const candidate = prefix.slice(commentStart);
-  if (!/^\/\*\*[\s\S]*?\*\/\s*$/.test(candidate)) return null;
-  return parseJsDocAnnotations(candidate);
+  const separator = value.indexOf(":");
+  const statusOrSchema = separator === -1 ? value : value.slice(0, separator);
+  const schemaName = separator === -1 ? null : value.slice(separator + 1);
+
+  if (isDigits(statusOrSchema)) {
+    return {
+      status: Number(statusOrSchema),
+      schemaName: schemaName || null,
+    };
+  }
+
+  return {
+    status: null,
+    schemaName: statusOrSchema,
+  };
 }
 
-function parseJsDocAnnotations(jsdoc: string): HandlerAnnotations {
-  // Extract summary (first non-tag line)
-  const summaryMatch = /\/\*\*\s*\n\s*\*\s*([^@\n][^\n]*)/.exec(jsdoc);
-  const summary = summaryMatch ? summaryMatch[1].trim().replace(/\.$/, "") : "";
-
+function parseJsDocAnnotations(jsdoc: ts.JSDoc): HandlerAnnotations {
+  const firstSummaryLine =
+    jsDocCommentText(jsdoc.comment)
+      .split("\n")
+      .map((line) => line.trim())
+      .find(Boolean) ?? "";
+  const summary = firstSummaryLine.endsWith(".")
+    ? firstSummaryLine.slice(0, -1)
+    : firstSummaryLine;
   const annotations: HandlerAnnotations = { summary, responses: [] };
 
-  // @params schemaName (query params)
-  const paramsMatch = /@params\s+(\w+)/.exec(jsdoc);
-  if (paramsMatch) annotations.params = paramsMatch[1];
-
-  // @pathParams schemaName
-  const pathParamsMatch = /@pathParams\s+(\w+)/.exec(jsdoc);
-  if (pathParamsMatch) annotations.pathParams = pathParamsMatch[1];
-
-  // @body schemaName
-  const bodyMatch = /@body\s+(\w+)/.exec(jsdoc);
-  if (bodyMatch) annotations.body = bodyMatch[1];
-
-  // @response schemaName, @response statusCode:schemaName, or @response statusCode (redirect/empty)
-  // Pattern: optional digits+colon prefix (status), then either word chars (schema) or end-of-context
-  const responsePattern = /@response\s+(?:(\d+)(?::(\w+))?|(\w+))/g;
-  let responseMatch = responsePattern.exec(jsdoc);
-  while (responseMatch !== null) {
-    if (responseMatch[1] !== undefined) {
-      // Matched @response STATUS or @response STATUS:SCHEMA
-      const status = Number(responseMatch[1]);
-      annotations.responses.push({
-        status,
-        schemaName: responseMatch[2] ?? null,
-      });
-    } else {
-      // Matched @response SCHEMA (no explicit status code)
-      annotations.responses.push({
-        status: null,
-        schemaName: responseMatch[3],
-      });
+  for (const tag of jsdoc.tags ?? []) {
+    const value = firstTagValue(tag);
+    switch (tag.tagName.text) {
+      case "params":
+        annotations.params = value;
+        break;
+      case "pathParams":
+        annotations.pathParams = value;
+        break;
+      case "body":
+        annotations.body = value;
+        break;
+      case "response": {
+        const response = parseResponseTagValue(value);
+        if (response) {
+          annotations.responses.push(response);
+        }
+        break;
+      }
     }
-    responseMatch = responsePattern.exec(jsdoc);
   }
 
   return annotations;
+}
+
+function parseNodeJsDocAnnotations(node: ts.Node): HandlerAnnotations | null {
+  const jsDoc = getNodeJsDoc(node);
+  return jsDoc ? parseJsDocAnnotations(jsDoc) : null;
+}
+
+function isNamedCallExpression(expression: ts.Expression, name: string) {
+  if (ts.isIdentifier(expression)) {
+    return expression.text === name;
+  }
+  return (
+    ts.isPropertyAccessExpression(expression) && expression.name.text === name
+  );
+}
+
+function getObservedApiRouteHandlerName(expression: ts.Expression | null) {
+  if (!expression) {
+    return null;
+  }
+
+  let handlerName: string | null = null;
+  function visit(node: ts.Node) {
+    if (handlerName) {
+      return;
+    }
+    if (
+      ts.isCallExpression(node) &&
+      isNamedCallExpression(node.expression, "observedApiRoute")
+    ) {
+      const firstArgument = node.arguments[0];
+      if (firstArgument && ts.isIdentifier(firstArgument)) {
+        handlerName = firstArgument.text;
+      }
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(expression);
+  return handlerName;
+}
+
+function findTopLevelFunction(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.FunctionDeclaration | null {
+  for (const statement of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(statement) && statement.name?.text === name) {
+      return statement;
+    }
+  }
+  return null;
+}
+
+function extractJsDocAnnotations(routeExport: RouteExport) {
+  const exportAnnotations = parseNodeJsDocAnnotations(routeExport.node);
+  if (exportAnnotations) {
+    return exportAnnotations;
+  }
+
+  const handlerName = getObservedApiRouteHandlerName(routeExport.initializer);
+  if (!handlerName) {
+    return null;
+  }
+
+  const handler = findTopLevelFunction(routeExport.sourceFile, handlerName);
+  return handler ? parseNodeJsDocAnnotations(handler) : null;
 }
 
 // ── Request params building ────────────────────────────────────────────────────
@@ -391,12 +453,12 @@ async function processRouteFile(
   const pathItem: OpenApiPathItem = {};
 
   for (const method of HTTP_METHODS) {
-    const exportKind = getRouteExportKind(source, method);
-    if (!exportKind) {
+    const routeExport = getRouteExport(source, method);
+    if (!routeExport) {
       continue;
     }
 
-    const annotations = extractJsDocAnnotations(source, method, exportKind);
+    const annotations = extractJsDocAnnotations(routeExport);
     if (!annotations) {
       if (method === "OPTIONS") {
         continue;

--- a/tools/dev/check/contracts.ts
+++ b/tools/dev/check/contracts.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import Ajv2020 from "ajv/dist/2020";
+import { getRegisteredMcpToolNames } from "../../shared/mcp-tool-registrations";
 import { getExportedRouteMethods } from "../../shared/route-exports";
 import { fail, reportUnexpectedError, walkFiles } from "./common";
 
@@ -339,15 +340,14 @@ function checkContractsDoc() {
   }
 
   function collectImplementedMcpTools(): Set<string> {
-    const toolPattern = /registerTool\(\s*["']([^"']+)["']/g;
     const tools = new Set<string>();
 
     for (const file of walkFiles(mcpDir).filter((item) =>
       item.endsWith(".ts"),
     )) {
       const source = readFileSync(file, "utf8");
-      for (const match of source.matchAll(toolPattern)) {
-        tools.add(match[1]);
+      for (const toolName of getRegisteredMcpToolNames(source)) {
+        tools.add(toolName);
       }
     }
 

--- a/tools/shared/mcp-tool-registrations.ts
+++ b/tools/shared/mcp-tool-registrations.ts
@@ -1,0 +1,53 @@
+import * as ts from "typescript";
+
+function isRegisterToolCallExpression(expression: ts.Expression) {
+  if (ts.isIdentifier(expression)) {
+    return expression.text === "registerTool";
+  }
+
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    expression.name.text === "registerTool"
+  );
+}
+
+function getStringLiteralValue(expression: ts.Expression): string | null {
+  if (
+    ts.isStringLiteral(expression) ||
+    ts.isNoSubstitutionTemplateLiteral(expression)
+  ) {
+    return expression.text;
+  }
+
+  return null;
+}
+
+export function getRegisteredMcpToolNames(source: string) {
+  const sourceFile = ts.createSourceFile(
+    "mcp-tool.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const toolNames: string[] = [];
+
+  function visit(node: ts.Node) {
+    if (
+      ts.isCallExpression(node) &&
+      isRegisterToolCallExpression(node.expression)
+    ) {
+      const toolName = node.arguments[0]
+        ? getStringLiteralValue(node.arguments[0])
+        : null;
+      if (toolName) {
+        toolNames.push(toolName);
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return toolNames;
+}

--- a/tools/shared/route-exports.ts
+++ b/tools/shared/route-exports.ts
@@ -12,6 +12,22 @@ export const HTTP_METHODS = [
 
 export type HttpMethod = (typeof HTTP_METHODS)[number];
 export type RouteExportKind = "function" | "const" | "destructured";
+export type RouteExport = {
+  kind: RouteExportKind;
+  node: ts.FunctionDeclaration | ts.VariableStatement;
+  initializer: ts.Expression | null;
+  sourceFile: ts.SourceFile;
+};
+
+function createRouteSourceFile(source: string) {
+  return ts.createSourceFile(
+    "route.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
 
 function hasExportModifier(node: ts.Node) {
   return Boolean(
@@ -49,18 +65,22 @@ export function getRouteExportKind(
   source: string,
   httpMethod: HttpMethod,
 ): RouteExportKind | null {
-  const sourceFile = ts.createSourceFile(
-    "route.ts",
-    source,
-    ts.ScriptTarget.Latest,
-    false,
-    ts.ScriptKind.TS,
-  );
+  return getRouteExport(source, httpMethod)?.kind ?? null;
+}
 
+function getRouteExportFromSourceFile(
+  sourceFile: ts.SourceFile,
+  httpMethod: HttpMethod,
+): RouteExport | null {
   for (const statement of sourceFile.statements) {
     if (ts.isFunctionDeclaration(statement)) {
       if (hasExportModifier(statement) && statement.name?.text === httpMethod) {
-        return "function";
+        return {
+          kind: "function",
+          node: statement,
+          initializer: null,
+          sourceFile,
+        };
       }
       continue;
     }
@@ -75,13 +95,23 @@ export function getRouteExportKind(
 
     for (const declaration of statement.declarationList.declarations) {
       if (bindingNameExportsMethod(declaration.name, httpMethod)) {
-        return "const";
+        return {
+          kind: "const",
+          node: statement,
+          initializer: declaration.initializer ?? null,
+          sourceFile,
+        };
       }
       if (
         ts.isObjectBindingPattern(declaration.name) &&
         objectBindingExportsMethod(declaration.name, httpMethod)
       ) {
-        return "destructured";
+        return {
+          kind: "destructured",
+          node: statement,
+          initializer: declaration.initializer ?? null,
+          sourceFile,
+        };
       }
     }
   }
@@ -89,9 +119,22 @@ export function getRouteExportKind(
   return null;
 }
 
+export function getRouteExport(
+  source: string,
+  httpMethod: HttpMethod,
+): RouteExport | null {
+  return getRouteExportFromSourceFile(
+    createRouteSourceFile(source),
+    httpMethod,
+  );
+}
+
 export function getExportedRouteMethods(
   source: string,
   methods: readonly HttpMethod[] = HTTP_METHODS,
 ) {
-  return methods.filter((method) => getRouteExportKind(source, method));
+  const sourceFile = createRouteSourceFile(source);
+  return methods.filter((method) =>
+    getRouteExportFromSourceFile(sourceFile, method),
+  );
 }


### PR DESCRIPTION
## Goal

Close #220 by replacing broad source regex parsing in OpenAPI/contract source inspection with TypeScript AST readers where practical.

## Changed Surfaces

- `tools/shared/route-exports.ts` now exposes AST-backed route export metadata in addition to method detection.
- `tools/build/openapi/generate-spec.ts` reads route export and JSDoc annotation metadata through TypeScript AST instead of broad export regex scans.
- `tools/shared/mcp-tool-registrations.ts` adds an AST reader for static MCP `registerTool` names.
- `tools/dev/check/contracts.ts` uses the MCP AST reader for implemented tool collection.
- Added focused unit coverage for route export metadata and MCP tool registration parsing.

## Evidence

- `bunx vitest run tests/unit/route-exports.test.ts tests/unit/mcp-tool-registrations.test.ts`
- `bun run openapi:check`
- `bun run check:contracts`
- Worker also ran `bun run openapi:generate` and confirmed no `public/openapi.generated.json` diff.
- Worker ran `DATABASE_URL=... bun run verify`.

Complete-loop runtime evidence: N/A for app behavior; this is tooling-only source inspection. The generated OpenAPI output remains unchanged.

## Docs / Contracts

No contract JSON, OpenAPI output, route behavior, MCP tool behavior, or user docs changed.

## Risk Areas

Tooling/source inspection. The main risk is missing a supported route export or MCP registration pattern; focused unit tests cover function, const, destructured route exports, ignored aliases/comments/strings, export-owned JSDoc metadata, and static MCP tool names.

## Cleanup

No scratch artifacts, generated file diffs, one-time probes, or unrelated rewrites are included.
