### PR TITLE
feat(seo/ui): dynamic sitemap and simplify section calendar tab

### DIFF
--- a/src/features/section-detail/components/SectionCalendarTab.svelte
+++ b/src/features/section-detail/components/SectionCalendarTab.svelte
@@ -3,7 +3,6 @@ import type { CalendarGridWeek } from "$lib/components/calendar/types";
 import CalendarIcon from "$lib/components/icons/calendar.svelte";
 import { Alert } from "$lib/components/ui/alert/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
-import SectionCalendarEventCard from "./SectionCalendarEventCard.svelte";
 import SectionCalendarMonthView from "./SectionCalendarMonthView.svelte";
 import SectionCalendarUnscheduledEvents from "./SectionCalendarUnscheduledEvents.svelte";
 import type {
@@ -15,7 +14,6 @@ export let calendarGridWeeks: CalendarGridWeek[];
 export let calendarMonthLabel: string;
 export let calendarMonthOffset: number;
 export let dateTimePlaceText: string | null | undefined;
-export let fmtDate: (value: string | Date | null | undefined) => string;
 export let formatMessage: (
   template: string,
   values: Record<string, string>,
@@ -48,12 +46,6 @@ export let unscheduledCalendarEvents: SectionCalendarEvent[];
       {sectionCopy}
       {todayCalendarMonthOffset}
     />
-
-    <section class="grid gap-3">
-      {#each sectionCalendarEvents.filter((event) => event.dateKey) as event}
-        <SectionCalendarEventCard {event} {fmtDate} {sectionCopy} />
-      {/each}
-    </section>
 
     {#if unscheduledCalendarEvents.length > 0}
       <SectionCalendarUnscheduledEvents

--- a/src/features/section-detail/components/SectionDetailMainContent.svelte
+++ b/src/features/section-detail/components/SectionDetailMainContent.svelte
@@ -102,7 +102,6 @@ function sectionPanelId(id: SectionDetailMainContentProps["activeTab"]) {
           calendarGridWeeks={sectionCalendarGridWeeks}
           {calendarMonthLabel}
           dateTimePlaceText={data.section.dateTimePlaceText}
-          {fmtDate}
           {formatMessage}
           {openCalendarDialog}
           {sectionCalendarEvents}

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,7 +1,8 @@
+import { prisma } from "@/lib/db/prisma";
 import { getCanonicalOrigin } from "@/lib/site-url";
 import type { RequestHandler } from "./$types";
 
-const ROUTES = [
+const STATIC_ROUTES = [
   "/",
   "/courses",
   "/sections",
@@ -12,9 +13,29 @@ const ROUTES = [
   "/terms",
 ];
 
-export const GET: RequestHandler = () => {
+async function getEntityUrls(origin: string) {
+  const [courses, sections, teachers] = await Promise.all([
+    prisma.course.findMany({ select: { jwId: true } }),
+    prisma.section.findMany({ select: { jwId: true } }),
+    prisma.teacher.findMany({ select: { id: true } }),
+  ]);
+
+  const courseUrls = courses.map(({ jwId }) => `${origin}/courses/${jwId}`);
+  const sectionUrls = sections.map(({ jwId }) => `${origin}/sections/${jwId}`);
+  const teacherUrls = teachers.map(({ id }) => `${origin}/teachers/${id}`);
+
+  return [...courseUrls, ...sectionUrls, ...teacherUrls];
+}
+
+export const GET: RequestHandler = async () => {
   const origin = getCanonicalOrigin();
-  const body = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${ROUTES.map((route) => `  <url><loc>${origin}${route}</loc></url>`).join("\n")}\n</urlset>\n`;
+  const entityUrls = await getEntityUrls(origin);
+  const urls = [
+    ...STATIC_ROUTES.map((route) => `${origin}${route}`),
+    ...entityUrls,
+  ];
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.map((loc) => `  <url><loc>${loc}</loc></url>`).join("\n")}\n</urlset>\n`;
   return new Response(body, {
     headers: { "Content-Type": "application/xml; charset=utf-8" },
   });

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -245,30 +245,35 @@ test.describe("/sections/[jwId] 班级详情页", () => {
       intervals: [250, 500, 1_000],
     });
 
-    const classEvent = page
-      .locator("article")
+    // Class schedule information is now rendered as chips inside the calendar
+    // month grid, not as a separate list of cards.
+    const monthView = getSectionCalendarMonthView(page);
+    const classEventChip = monthView
+      .locator("a")
       .filter({ hasText: /上课事件|Class event/i })
       .first();
-    await expect(classEvent).toBeVisible();
+    await expect(classEventChip).toBeVisible();
 
     // schedule.room.namePrimary and schedule.room.building.namePrimary
-    // are rendered in the event detail cards.
+    // are rendered in the chip meta text.
     await expect(
-      classEvent
+      classEventChip
         .getByText(DEV_SEED.room.nameCn, { exact: false })
-        .or(classEvent.getByText(DEV_SEED.room.nameEn, { exact: false }))
+        .or(classEventChip.getByText(DEV_SEED.room.nameEn, { exact: false }))
         .first(),
     ).toBeVisible();
     await expect(
-      classEvent
+      classEventChip
         .getByText(DEV_SEED.building.nameCn, { exact: false })
-        .or(classEvent.getByText(DEV_SEED.building.nameEn, { exact: false }))
+        .or(
+          classEventChip.getByText(DEV_SEED.building.nameEn, { exact: false }),
+        )
         .first(),
     ).toBeVisible();
     await expect(
-      classEvent
+      classEventChip
         .getByText(DEV_SEED.campus.nameCn, { exact: false })
-        .or(classEvent.getByText(DEV_SEED.campus.nameEn, { exact: false }))
+        .or(classEventChip.getByText(DEV_SEED.campus.nameEn, { exact: false }))
         .first(),
     ).toBeVisible();
 


### PR DESCRIPTION
## Summary

Addresses three requests:

1. **SEO**: `sitemap.xml` now includes an index URL for every course, section, and teacher.
2. **Production page failure**: investigated `/sections/174923` via Wrangler tail; root cause identified.
3. **UI**: the section calendar tab no longer renders the per-event card list below the calendar grid.

## 1. Dynamic sitemap

`/sitemap.xml` was previously a static list of top-level routes. It now queries `course.jwId`, `section.jwId`, and `teacher.id` and emits URLs for:

- `/courses/{jwId}`
- `/sections/{jwId}`
- `/teachers/{id}`

## 2. `/sections/174923` failure (operational fix needed)

Wrangler tail captured the failing request:

```json
{
  "event": "sveltekit.server-error",
  "method": "GET",
  "path": "/sections/174923",
  "status": 500,
  "error": {
    "name": "PrismaClientKnownRequestError",
    "message": "The column `SectionTeacher.retiredAt` does not exist in the current database."
  }
}
```

The migration `prisma/migrations/20260625162000_add_section_teacher_retired_at/migration.sql` exists in the repo but has **not been applied to the production database**. Apply it with:

```bash
DATABASE_URL=<production-url> npx prisma migrate deploy
```

No code change is required for this part.

## 3. Section calendar tab redesign

Removed the `{#each sectionCalendarEvents ...} <SectionCalendarEventCard />` block from the calendar tab. The month-view calendar grid (with its day/event cards) and the unscheduled-events list are preserved.

## Verification

- `bunx biome check` passed on changed files.
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json` passed.
