### PR TITLE
fix(oauth): consent token flow

### DIFF
--- a/src/features/oauth/server/device-token-issuer.server.ts
+++ b/src/features/oauth/server/device-token-issuer.server.ts
@@ -130,9 +130,9 @@ export async function issueDeviceGrantTokens(
   const accessTokenHash = jwtAccessToken
     ? undefined
     : await hashOAuthClientSecretForDbStorage(accessToken);
-  const shouldIssueRefreshToken =
-    input.resources.length === 0 &&
-    input.scopes.includes(OAUTH_OFFLINE_ACCESS_SCOPE);
+  const shouldIssueRefreshToken = input.scopes.includes(
+    OAUTH_OFFLINE_ACCESS_SCOPE,
+  );
   const refreshToken = shouldIssueRefreshToken
     ? randomBytesBase64Url(32)
     : undefined;

--- a/src/features/oauth/server/oauth-consent-action.ts
+++ b/src/features/oauth/server/oauth-consent-action.ts
@@ -25,26 +25,60 @@ export async function submitOAuthConsentAction({
   const headers = new Headers(request.headers);
   headers.delete("content-length");
   headers.set("accept", "application/json");
+  headers.set("content-type", "application/json");
 
   let redirectTarget: string | undefined;
   try {
-    const { authApi } = await import("@/lib/auth/core");
+    const authCore = await import("@/lib/auth/core");
+    const authApi = authCore.authApi;
+    const betterAuthInstance = Object.hasOwn(authCore, "betterAuthInstance")
+      ? authCore.betterAuthInstance
+      : undefined;
     const consentUrl = new URL("/api/auth/oauth2/consent", request.url);
-    const payload = await asOAuthProviderApi(authApi).oauth2Consent({
-      asResponse: false,
-      headers,
-      request: new Request(consentUrl, {
-        method: "POST",
+    const body = {
+      accept,
+      scope,
+      oauth_query: oauthQuery,
+    };
+    try {
+      if (typeof betterAuthInstance?.handler === "function") {
+        const response = await betterAuthInstance.handler(
+          new Request(consentUrl, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(body),
+          }),
+        );
+        const payload = (await response
+          .clone()
+          .json()
+          .catch(() => null)) as {
+          redirect_uri?: string;
+          redirectURI?: string;
+          url?: string;
+        } | null;
+        redirectTarget =
+          response.headers.get("location") ??
+          payload?.redirect_uri ??
+          payload?.redirectURI ??
+          payload?.url;
+      }
+    } catch {
+      redirectTarget = undefined;
+    }
+    if (!redirectTarget) {
+      const payload = await asOAuthProviderApi(authApi).oauth2Consent({
+        asResponse: false,
         headers,
-      }),
-      body: {
-        accept,
-        scope,
-        oauth_query: oauthQuery,
-      },
-    });
-    redirectTarget =
-      payload?.redirect_uri ?? payload?.redirectURI ?? payload?.url;
+        request: new Request(consentUrl, {
+          method: "POST",
+          headers,
+        }),
+        body,
+      });
+      redirectTarget =
+        payload?.redirect_uri ?? payload?.redirectURI ?? payload?.url;
+    }
   } catch {
     redirectTarget = undefined;
   }

--- a/tests/e2e/src/app/oauth/device/test.ts
+++ b/tests/e2e/src/app/oauth/device/test.ts
@@ -381,7 +381,7 @@ test("/oauth/device 资源绑定令牌可访问 REST 与 MCP", async ({
       resources,
     );
     expect(accessToken.split(".")).toHaveLength(3);
-    expect(refreshToken).toBeUndefined();
+    expect(refreshToken).toEqual(expect.any(String));
 
     const todosResponse = await request.get("/api/todos", {
       headers: {

--- a/tests/unit/oauth-device-token-issuer.test.ts
+++ b/tests/unit/oauth-device-token-issuer.test.ts
@@ -45,7 +45,7 @@ describe("设备令牌签发器", () => {
     signJwtMock.mockReset();
   });
 
-  it("使用绑定资源的 JWT 访问令牌且不签发刷新令牌", async () => {
+  it("使用绑定资源的 JWT 访问令牌且为 offline_access 签发刷新令牌", async () => {
     signJwtMock.mockResolvedValue({ token: "header.payload.signature" });
     const { prisma, accessTokenCreate, refreshTokenCreate } =
       createPrismaMock();
@@ -71,10 +71,25 @@ describe("设备令牌签发器", () => {
 
     expect(issued).toMatchObject({
       accessToken: "header.payload.signature",
+      refreshToken: expect.any(String),
     });
-    expect(issued).not.toHaveProperty("refreshToken");
     expect(accessTokenCreate).not.toHaveBeenCalled();
-    expect(refreshTokenCreate).not.toHaveBeenCalled();
+    expect(refreshTokenCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        clientId: "client-1",
+        resources: [
+          "https://life.example/api/auth",
+          "https://life.example/api/mcp",
+        ],
+        scopes: [
+          OAUTH_OPENID_SCOPE,
+          OAUTH_PROFILE_SCOPE,
+          MCP_TOOLS_SCOPE,
+          OAUTH_OFFLINE_ACCESS_SCOPE,
+        ],
+        userId: "user-1",
+      }),
+    });
     expect(signJwtMock).toHaveBeenCalledWith({
       body: {
         payload: expect.objectContaining({


### PR DESCRIPTION
## Summary
- Route custom OAuth consent submissions through the Better Auth handler so cookie/session middleware resolves the consenting user.
- Issue device-flow refresh tokens whenever `offline_access` is requested, including resource-bound device grants.

## Root Cause
The custom Svelte consent action called the Better Auth direct API surface for `/oauth2/consent`. In production this looped back to the consent page after approval, consistent with the consent endpoint not seeing the user-bound request/session context. Separately, the device-code issuer suppressed refresh tokens whenever a requested resource was present, so Bot credentials could not refresh despite requesting `offline_access`.

## Validation
- `bunx biome check src/features/oauth/server/oauth-consent-action.ts src/features/oauth/server/device-token-issuer.server.ts`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bun run build`
- Reproduced production consent loop through persistent CDP before the fix.