### PR TITLE
fix(oauth): loopback form action CSP

### DIFF
--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -17,6 +17,11 @@ const EXTERNAL_IMAGE_SOURCES = [
   "https://api.dicebear.com",
 ];
 
+const LOOPBACK_FORM_ACTION_SOURCES = [
+  "http://localhost:*",
+  "http://127.0.0.1:*",
+];
+
 export function createScriptNonce() {
   const bytes = crypto.getRandomValues(new Uint8Array(16));
   const value = String.fromCharCode(...bytes);
@@ -47,7 +52,7 @@ export function buildContentSecurityPolicy(
     "font-src 'self' https://fonts.gstatic.com",
     `connect-src 'self' ${connectSources.join(" ")}`,
     "frame-ancestors 'none'",
-    "form-action 'self'",
+    `form-action 'self' ${LOOPBACK_FORM_ACTION_SOURCES.join(" ")}`,
     "base-uri 'self'",
     "object-src 'none'",
   ];


### PR DESCRIPTION
## Summary
- allow OAuth consent form redirects to CLI loopback callback origins in CSP
- cover both localhost and 127.0.0.1 wildcard ports

## Root Cause
The consent API returned the correct localhost callback, but the browser stayed on /oauth/authorize because the production CSP had `form-action 'self'`, blocking the native form redirect to the CLI callback listener.

## Validation
- `bunx biome check src/lib/security/csp.ts`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx vitest run tests/unit/csp.test.ts`
- `bun run build`