### PR TITLE
fix(auth): REST bearer JWKS verification

### DIFF
--- a/src/lib/auth/api-auth.ts
+++ b/src/lib/auth/api-auth.ts
@@ -36,6 +36,11 @@ function hasAnyRestScope(scopes: Set<string>): boolean {
   return [...scopes].some(isFeatureScope);
 }
 
+async function getLocalJwks() {
+  const { authApi } = await import("@/lib/auth/core");
+  return authApi.getJwks({});
+}
+
 /**
  * Resolve the authenticated user ID from a request.
  *
@@ -53,6 +58,7 @@ export async function resolveApiUserId(
     if (!token) return null;
     try {
       const verified = await verifyAccessTokenJwt(token, {
+        jwksFetch: getLocalJwks,
         jwksUrl: getJwksUrlForOAuthVerification(),
         issuer: getOAuthTokenVerificationIssuers(),
         audience: getOAuthRestAudienceUrls(),

--- a/src/lib/auth/jwt-verification.ts
+++ b/src/lib/auth/jwt-verification.ts
@@ -1,3 +1,5 @@
+import { verifyJwsAccessToken } from "better-auth/oauth2";
+import type { JSONWebKeySet, JWTVerifyOptions } from "jose";
 import { createRemoteJWKSet, jwtVerify } from "jose";
 import { expandScopeClaim } from "@/lib/oauth/scope-registry";
 
@@ -10,16 +12,28 @@ export interface VerifiedAccessToken {
 export async function verifyAccessTokenJwt(
   token: string,
   options: {
+    jwksFetch?: () => Promise<JSONWebKeySet | undefined>;
     jwksUrl: string;
     issuer: string | string[];
     audience: string | string[];
   },
 ): Promise<VerifiedAccessToken> {
-  const JWKS = createRemoteJWKSet(new URL(options.jwksUrl));
-  const { payload } = await jwtVerify(token, JWKS, {
+  const verifyOptions: JWTVerifyOptions &
+    Required<Pick<JWTVerifyOptions, "issuer" | "audience">> = {
     issuer: options.issuer,
     audience: options.audience,
-  });
+  };
+  const payload = options.jwksFetch
+    ? await verifyJwsAccessToken(token, {
+        jwksFetch: options.jwksFetch,
+        verifyOptions,
+      })
+    : (
+        await jwtVerify(token, createRemoteJWKSet(new URL(options.jwksUrl)), {
+          issuer: options.issuer,
+          audience: options.audience,
+        })
+      ).payload;
   const sub = payload.sub;
   if (!sub) throw new Error("Missing sub claim");
   return {


### PR DESCRIPTION
## Summary
- verify REST bearer JWTs with Better Auth's local JWKS endpoint instead of requiring a remote JWKS fetch
- preserve the existing remote JWKS verifier path for callers that do not provide a local JWKS fetcher

## Root Cause
Production CLI login produced a structurally valid EdDSA access token, and local verification against the production JWKS succeeded, but production REST API calls returned 401. The REST verifier was the only path forcing a remote JWKS fetch through the public deployment URL during request handling.

## Validation
- `bunx biome check src/lib/auth/jwt-verification.ts src/lib/auth/api-auth.ts`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx vitest run tests/unit/auth-helpers.test.ts tests/unit/lib/auth/jwt-verification.test.ts`