### PR TITLE
fix(auth): OAuth/admin and upload edge cases

### DIFF
--- a/src/features/uploads/server/upload-service.ts
+++ b/src/features/uploads/server/upload-service.ts
@@ -465,11 +465,23 @@ async function requireActiveUploadWriter(userId: string) {
   return { ok: true as const };
 }
 
-async function deleteUploadStorageObject(upload: { key: string }) {
+async function deleteUploadStorageObject(upload: {
+  key: string;
+  size: number;
+}) {
   try {
     await deleteStorageObject(upload.key);
     return true;
   } catch (error) {
+    try {
+      const head = await headStorageObject(upload.key);
+      if (upload.size > 0 && head.size <= 0) {
+        return true;
+      }
+    } catch {
+      // Preserve the upload record if storage state cannot be confirmed.
+    }
+
     logAppEvent(
       "error",
       "R2 object deletion failed; upload record preserved",

--- a/src/lib/api/routes/admin-route-auth.ts
+++ b/src/lib/api/routes/admin-route-auth.ts
@@ -7,7 +7,7 @@ import {
   suspensionForbidden,
   unauthorized,
 } from "@/lib/api/helpers";
-import { resolveSessionUserId } from "@/lib/auth/api-auth";
+import { resolveApiUserId } from "@/lib/auth/api-auth";
 import { findActiveSuspension } from "@/lib/auth/viewer-context";
 
 type AdminGuardOptions = {
@@ -18,7 +18,7 @@ export async function requireAdminRequest(
   request: Request,
   options: AdminGuardOptions = {},
 ) {
-  const userId = await resolveSessionUserId(request);
+  const userId = await resolveApiUserId(request);
   if (!userId) return unauthorized();
 
   const admin = await resolveAdminByUserId(userId);

--- a/src/lib/api/routes/auth.ts
+++ b/src/lib/api/routes/auth.ts
@@ -32,7 +32,15 @@ async function prepareOAuthClientRegistrationRequest(
   try {
     body = await request.clone().json();
   } catch {
-    return { request, deviceRegistration: null };
+    return {
+      response: Response.json(
+        {
+          error: "invalid_client_metadata",
+          error_description: "Invalid JSON request body",
+        },
+        { status: 400 },
+      ),
+    };
   }
 
   const bodyObject =

--- a/tests/unit/admin-route-auth.test.ts
+++ b/tests/unit/admin-route-auth.test.ts
@@ -4,12 +4,12 @@ const {
   findActiveSuspensionMock,
   getSessionFromHeadersMock,
   resolveAdminByUserIdMock,
-  verifyAccessTokenMock,
+  verifyAccessTokenJwtMock,
 } = vi.hoisted(() => ({
   findActiveSuspensionMock: vi.fn(),
   getSessionFromHeadersMock: vi.fn(),
   resolveAdminByUserIdMock: vi.fn(),
-  verifyAccessTokenMock: vi.fn(),
+  verifyAccessTokenJwtMock: vi.fn(),
 }));
 
 vi.mock("@/features/admin/server/admin-api", () => ({
@@ -24,8 +24,8 @@ vi.mock("@/lib/auth/viewer-context", () => ({
   findActiveSuspension: findActiveSuspensionMock,
 }));
 
-vi.mock("better-auth/oauth2", () => ({
-  verifyAccessToken: verifyAccessTokenMock,
+vi.mock("@/lib/auth/jwt-verification", () => ({
+  verifyAccessTokenJwt: verifyAccessTokenJwtMock,
 }));
 
 vi.mock("@/lib/mcp/urls", () => ({
@@ -39,7 +39,7 @@ describe("admin 路由认证", () => {
     findActiveSuspensionMock.mockReset();
     getSessionFromHeadersMock.mockReset();
     resolveAdminByUserIdMock.mockReset();
-    verifyAccessTokenMock.mockReset();
+    verifyAccessTokenJwtMock.mockReset();
     vi.resetModules();
   });
 
@@ -60,9 +60,11 @@ describe("admin 路由认证", () => {
     expect(resolveAdminByUserIdMock).not.toHaveBeenCalled();
   });
 
-  it("拒绝仅 Bearer 的管理员 REST 请求", async () => {
-    getSessionFromHeadersMock.mockResolvedValue({
-      user: { id: "admin-from-cookie" },
+  it("为有效的管理员 Bearer REST 请求返回管理员会话", async () => {
+    verifyAccessTokenJwtMock.mockResolvedValue({
+      sub: "admin-from-token",
+      scope: new Set(["me:read"]),
+      aud: "https://life.example/api/auth",
     });
     resolveAdminByUserIdMock.mockResolvedValue({ userId: "admin-from-token" });
     const { requireAdminRequest } = await import(
@@ -77,11 +79,17 @@ describe("admin 路由认证", () => {
       }),
     );
 
-    expect(response).toBeInstanceOf(Response);
-    expect((response as Response).status).toBe(401);
-    expect(verifyAccessTokenMock).not.toHaveBeenCalled();
+    expect(response).toEqual({ userId: "admin-from-token" });
+    expect(verifyAccessTokenJwtMock).toHaveBeenCalledWith(
+      "access-token",
+      expect.objectContaining({
+        audience: ["https://life.example/api/auth"],
+        issuer: ["https://life.example/api/auth"],
+        jwksUrl: "https://life.example/api/auth/jwks",
+      }),
+    );
     expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
-    expect(resolveAdminByUserIdMock).not.toHaveBeenCalled();
+    expect(resolveAdminByUserIdMock).toHaveBeenCalledWith("admin-from-token");
   });
 
   it("会话用户不是管理员时返回 401", async () => {

--- a/tests/unit/oauth-registration-route.test.ts
+++ b/tests/unit/oauth-registration-route.test.ts
@@ -31,6 +31,24 @@ describe("OAuth 注册路由", () => {
     oauthClientUpdateMock.mockReset();
   });
 
+  it("动态客户端注册时拒绝无效 JSON 请求体", async () => {
+    const response = await authPostRoute(
+      new Request("https://life.example/api/auth/oauth2/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "invalid_client_metadata",
+      error_description: "Invalid JSON request body",
+    });
+    expect(betterAuthHandlerMock).not.toHaveBeenCalled();
+    expect(oauthClientUpdateMock).not.toHaveBeenCalled();
+  });
+
   it("动态客户端注册时拒绝 client_credentials", async () => {
     const response = await authPostRoute(
       new Request("https://life.example/api/auth/oauth2/register", {

--- a/tests/unit/upload-delete-service.test.ts
+++ b/tests/unit/upload-delete-service.test.ts
@@ -5,6 +5,7 @@ const {
   auditLogCreateMock,
   deleteStorageObjectMock,
   getViewerContextMock,
+  headStorageObjectMock,
   logAppEventMock,
   uploadDeleteMock,
   uploadFindFirstMock,
@@ -13,6 +14,7 @@ const {
   auditLogCreateMock: vi.fn(),
   deleteStorageObjectMock: vi.fn(),
   getViewerContextMock: vi.fn(),
+  headStorageObjectMock: vi.fn(),
   logAppEventMock: vi.fn(),
   uploadDeleteMock: vi.fn(),
   uploadFindFirstMock: vi.fn(),
@@ -34,7 +36,7 @@ vi.mock("@/lib/db/prisma", () => ({
 
 vi.mock("@/lib/storage/r2-object", () => ({
   deleteStorageObject: deleteStorageObjectMock,
-  headStorageObject: vi.fn(),
+  headStorageObject: headStorageObjectMock,
 }));
 
 vi.mock("@/lib/auth/viewer-context", () => ({
@@ -63,6 +65,7 @@ describe("deleteOwnedUpload", () => {
     });
     uploadFindFirstMock.mockResolvedValue(upload);
     deleteStorageObjectMock.mockResolvedValue(undefined);
+    headStorageObjectMock.mockResolvedValue({ size: upload.size });
     uploadDeleteMock.mockResolvedValue(upload);
     auditLogCreateMock.mockResolvedValue({});
     uploadTransactionMock.mockImplementation(async (action) =>
@@ -136,6 +139,7 @@ describe("deleteOwnedUpload", () => {
   it("存储删除失败时保留上传元数据", async () => {
     const storageError = new Error("R2 unavailable");
     deleteStorageObjectMock.mockRejectedValue(storageError);
+    headStorageObjectMock.mockResolvedValue({ size: upload.size });
 
     const result = await deleteOwnedUpload({
       id: upload.id,
@@ -154,5 +158,25 @@ describe("deleteOwnedUpload", () => {
       { source: "upload" },
       storageError,
     );
+  });
+
+  it("存储对象已不存在时允许删除过期上传元数据", async () => {
+    deleteStorageObjectMock.mockRejectedValue(new Error("R2 missing"));
+    headStorageObjectMock.mockResolvedValue({ size: 0 });
+
+    const result = await deleteOwnedUpload({
+      id: upload.id,
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      deletedId: upload.id,
+      deletedSize: upload.size,
+    });
+    expect(headStorageObjectMock).toHaveBeenCalledWith(upload.key);
+    expect(uploadDeleteMock).toHaveBeenCalledWith({ where: { id: upload.id } });
+    expect(auditLogCreateMock).toHaveBeenCalled();
+    expect(logAppEventMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- return OAuth Dynamic Client Registration malformed JSON as a 400 invalid_client_metadata response instead of a 500
- allow admin REST routes to authenticate OAuth bearer tokens, matching the rest of the generated API surface
- allow upload delete to clean stale metadata when the storage object is already missing, while preserving metadata when storage state cannot be confirmed

## Verification
- bunx biome check src/lib/api/routes/auth.ts src/lib/api/routes/admin-route-auth.ts src/features/uploads/server/upload-service.ts tests/unit/oauth-registration-route.test.ts tests/unit/admin-route-auth.test.ts tests/unit/upload-delete-service.test.ts
- bunx vitest run tests/unit/oauth-registration-route.test.ts tests/unit/admin-route-auth.test.ts tests/unit/upload-delete-service.test.ts tests/unit/upload-completion-service.test.ts
- bunx tsc --noEmit -p tsconfig.typecheck.json