### PR TITLE
fix(todos): delete race

### DIFF
--- a/src/features/todos/server/todo-service.ts
+++ b/src/features/todos/server/todo-service.ts
@@ -268,9 +268,16 @@ export async function updateOwnedTodo(input: {
 }
 
 export async function deleteOwnedTodo(id: string, userId: string) {
-  const ownership = await requireOwnedTodo(id, userId);
-  if (!ownership.ok) return ownership;
+  const deleted = await prisma.todo.deleteMany({ where: { id, userId } });
+  if (deleted.count > 0) return { ok: true as const };
 
-  await prisma.todo.delete({ where: { id } });
-  return { ok: true as const };
+  const todo = await prisma.todo.findUnique({
+    where: { id },
+    select: { id: true, userId: true },
+  });
+  if (!todo) return { ok: false as const, error: "not_found" as const };
+  if (todo.userId !== userId) {
+    return { ok: false as const, error: "forbidden" as const };
+  }
+  return { ok: false as const, error: "not_found" as const };
 }

--- a/tests/unit/todo-service-delete.test.ts
+++ b/tests/unit/todo-service-delete.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { deleteOwnedTodo } from "@/features/todos/server/todo-service";
+
+const { todoDeleteManyMock, todoFindUniqueMock } = vi.hoisted(() => ({
+  todoDeleteManyMock: vi.fn(),
+  todoFindUniqueMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    todo: {
+      deleteMany: todoDeleteManyMock,
+      findUnique: todoFindUniqueMock,
+    },
+  },
+}));
+
+describe("deleteOwnedTodo", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes by id and owner in one write", async () => {
+    todoDeleteManyMock.mockResolvedValue({ count: 1 });
+
+    await expect(deleteOwnedTodo("todo-1", "user-1")).resolves.toEqual({
+      ok: true,
+    });
+
+    expect(todoDeleteManyMock).toHaveBeenCalledWith({
+      where: { id: "todo-1", userId: "user-1" },
+    });
+    expect(todoFindUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("returns not_found when the todo is already gone", async () => {
+    todoDeleteManyMock.mockResolvedValue({ count: 0 });
+    todoFindUniqueMock.mockResolvedValue(null);
+
+    await expect(deleteOwnedTodo("todo-1", "user-1")).resolves.toEqual({
+      ok: false,
+      error: "not_found",
+    });
+  });
+
+  it("returns forbidden when another user owns the todo", async () => {
+    todoDeleteManyMock.mockResolvedValue({ count: 0 });
+    todoFindUniqueMock.mockResolvedValue({ id: "todo-1", userId: "user-2" });
+
+    await expect(deleteOwnedTodo("todo-1", "user-1")).resolves.toEqual({
+      ok: false,
+      error: "forbidden",
+    });
+  });
+
+  it("treats stale same-user ownership reads as already deleted", async () => {
+    todoDeleteManyMock.mockResolvedValue({ count: 0 });
+    todoFindUniqueMock.mockResolvedValue({ id: "todo-1", userId: "user-1" });
+
+    await expect(deleteOwnedTodo("todo-1", "user-1")).resolves.toEqual({
+      ok: false,
+      error: "not_found",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- delete todos atomically by `{ id, userId }` instead of read-before-delete
- return not_found for stale same-user ownership reads rather than surfacing a 500

## Verification
- bunx biome check src/features/todos/server/todo-service.ts tests/unit/todo-service-delete.test.ts
- bunx vitest run tests/unit/todo-service-delete.test.ts tests/unit/todo-batch-route.test.ts
- bunx tsc --noEmit -p tsconfig.typecheck.json

## Production finding
Manual CLI smoke created todo IDs cmr23yxfz0000psp7rsfpxxj2 and cmr23zs4g0001psp7s1l5g80i; repeated DELETE on one returned 500, consistent with a stale read-before-delete race.