### PR TITLE
fix(upload): delete race

### DIFF
--- a/src/features/uploads/server/upload-service.ts
+++ b/src/features/uploads/server/upload-service.ts
@@ -367,15 +367,22 @@ export async function deleteOwnedUpload(input: {
     };
   }
 
-  await prisma.$transaction(async (tx) => {
-    await tx.upload.delete({ where: { id: upload.id } });
+  const metadataDeleted = await prisma.$transaction(async (tx) => {
+    const deleted = await tx.upload.deleteMany({
+      where: { id: upload.id, userId: input.userId },
+    });
+    if (deleted.count === 0) return false;
+
     await writeUploadDeleteAuditLog({
       audit: input.audit,
       client: tx,
       upload,
       userId: input.userId,
     });
+    return true;
   });
+  if (!metadataDeleted)
+    return { ok: false as const, error: "not_found" as const };
 
   return {
     ok: true as const,

--- a/tests/unit/upload-completion-service.test.ts
+++ b/tests/unit/upload-completion-service.test.ts
@@ -21,7 +21,7 @@ const {
   txUploadCreateMock,
   txUploadFindUniqueMock,
   uploadAggregateMock,
-  uploadDeleteMock,
+  uploadDeleteManyMock,
   uploadFindFirstMock,
   uploadFindUniqueMock,
   uploadTransactionMock,
@@ -41,7 +41,7 @@ const {
   txUploadCreateMock: vi.fn(),
   txUploadFindUniqueMock: vi.fn(),
   uploadAggregateMock: vi.fn(),
-  uploadDeleteMock: vi.fn(),
+  uploadDeleteManyMock: vi.fn(),
   uploadFindFirstMock: vi.fn(),
   uploadFindUniqueMock: vi.fn(),
   uploadTransactionMock: vi.fn(),
@@ -55,7 +55,7 @@ vi.mock("@/lib/db/prisma", () => ({
     },
     upload: {
       aggregate: uploadAggregateMock,
-      delete: uploadDeleteMock,
+      deleteMany: uploadDeleteManyMock,
       findFirst: uploadFindFirstMock,
       findUnique: uploadFindUniqueMock,
     },
@@ -296,7 +296,7 @@ describe("deleteOwnedUpload", () => {
       key: KEY,
       size: 10,
     });
-    uploadDeleteMock.mockResolvedValue({});
+    uploadDeleteManyMock.mockResolvedValue({ count: 1 });
     deleteStorageObjectMock.mockResolvedValue(undefined);
     auditLogCreateMock.mockResolvedValue({});
     uploadTransactionMock.mockImplementation(async (action) =>
@@ -305,7 +305,7 @@ describe("deleteOwnedUpload", () => {
           create: auditLogCreateMock,
         },
         upload: {
-          delete: uploadDeleteMock,
+          deleteMany: uploadDeleteManyMock,
           findFirst: uploadFindFirstMock,
         },
       }),

--- a/tests/unit/upload-delete-service.test.ts
+++ b/tests/unit/upload-delete-service.test.ts
@@ -7,7 +7,7 @@ const {
   getViewerContextMock,
   headStorageObjectMock,
   logAppEventMock,
-  uploadDeleteMock,
+  uploadDeleteManyMock,
   uploadFindFirstMock,
   uploadTransactionMock,
 } = vi.hoisted(() => ({
@@ -16,7 +16,7 @@ const {
   getViewerContextMock: vi.fn(),
   headStorageObjectMock: vi.fn(),
   logAppEventMock: vi.fn(),
-  uploadDeleteMock: vi.fn(),
+  uploadDeleteManyMock: vi.fn(),
   uploadFindFirstMock: vi.fn(),
   uploadTransactionMock: vi.fn(),
 }));
@@ -28,7 +28,7 @@ vi.mock("@/lib/db/prisma", () => ({
       create: auditLogCreateMock,
     },
     upload: {
-      delete: uploadDeleteMock,
+      deleteMany: uploadDeleteManyMock,
       findFirst: uploadFindFirstMock,
     },
   },
@@ -66,7 +66,7 @@ describe("deleteOwnedUpload", () => {
     uploadFindFirstMock.mockResolvedValue(upload);
     deleteStorageObjectMock.mockResolvedValue(undefined);
     headStorageObjectMock.mockResolvedValue({ size: upload.size });
-    uploadDeleteMock.mockResolvedValue(upload);
+    uploadDeleteManyMock.mockResolvedValue({ count: 1 });
     auditLogCreateMock.mockResolvedValue({});
     uploadTransactionMock.mockImplementation(async (action) =>
       action({
@@ -74,7 +74,7 @@ describe("deleteOwnedUpload", () => {
           create: auditLogCreateMock,
         },
         upload: {
-          delete: uploadDeleteMock,
+          deleteMany: uploadDeleteManyMock,
           findFirst: uploadFindFirstMock,
         },
       }),
@@ -98,9 +98,11 @@ describe("deleteOwnedUpload", () => {
       deletedSize: upload.size,
     });
     expect(deleteStorageObjectMock).toHaveBeenCalledWith(upload.key);
-    expect(uploadDeleteMock).toHaveBeenCalledWith({ where: { id: upload.id } });
+    expect(uploadDeleteManyMock).toHaveBeenCalledWith({
+      where: { id: upload.id, userId: "user-1" },
+    });
     expect(deleteStorageObjectMock.mock.invocationCallOrder[0]).toBeLessThan(
-      uploadDeleteMock.mock.invocationCallOrder[0],
+      uploadDeleteManyMock.mock.invocationCallOrder[0],
     );
     expect(auditLogCreateMock).toHaveBeenCalledWith({
       data: expect.objectContaining({
@@ -125,7 +127,9 @@ describe("deleteOwnedUpload", () => {
     ).rejects.toThrow(auditError);
 
     expect(deleteStorageObjectMock).toHaveBeenCalledWith(upload.key);
-    expect(uploadDeleteMock).toHaveBeenCalledWith({ where: { id: upload.id } });
+    expect(uploadDeleteManyMock).toHaveBeenCalledWith({
+      where: { id: upload.id, userId: "user-1" },
+    });
     expect(auditLogCreateMock).toHaveBeenCalledWith({
       data: expect.objectContaining({
         action: "upload_delete",
@@ -150,7 +154,7 @@ describe("deleteOwnedUpload", () => {
       ok: false,
       error: "storage_delete_failed",
     });
-    expect(uploadDeleteMock).not.toHaveBeenCalled();
+    expect(uploadDeleteManyMock).not.toHaveBeenCalled();
     expect(auditLogCreateMock).not.toHaveBeenCalled();
     expect(logAppEventMock).toHaveBeenCalledWith(
       "error",
@@ -175,8 +179,26 @@ describe("deleteOwnedUpload", () => {
       deletedSize: upload.size,
     });
     expect(headStorageObjectMock).toHaveBeenCalledWith(upload.key);
-    expect(uploadDeleteMock).toHaveBeenCalledWith({ where: { id: upload.id } });
+    expect(uploadDeleteManyMock).toHaveBeenCalledWith({
+      where: { id: upload.id, userId: "user-1" },
+    });
     expect(auditLogCreateMock).toHaveBeenCalled();
     expect(logAppEventMock).not.toHaveBeenCalled();
+  });
+
+  it("上传元数据已不存在时返回 not_found 而不是抛出", async () => {
+    uploadDeleteManyMock.mockResolvedValue({ count: 0 });
+
+    const result = await deleteOwnedUpload({
+      id: upload.id,
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "not_found",
+    });
+    expect(deleteStorageObjectMock).toHaveBeenCalledWith(upload.key);
+    expect(auditLogCreateMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- delete upload metadata with `deleteMany({ id, userId })` inside the transaction
- return not_found for stale upload metadata rows instead of surfacing a 500
- update upload delete tests for the atomic metadata delete path

## Verification
- bunx biome check src/features/uploads/server/upload-service.ts tests/unit/upload-delete-service.test.ts tests/unit/upload-completion-service.test.ts
- bunx vitest run tests/unit/upload-delete-service.test.ts tests/unit/upload-completion-service.test.ts
- bunx tsc --noEmit -p tsconfig.typecheck.json

## Production finding
After a successful upload delete, production list briefly returned a stale upload row; a repeated DELETE returned 500. This mirrors the todo delete race and should now become not_found/no-500.