### PR TITLE
fix(oauth): consent callback redirect

### DIFF
--- a/src/features/oauth/server/oauth-consent-action.ts
+++ b/src/features/oauth/server/oauth-consent-action.ts
@@ -31,54 +31,23 @@ export async function submitOAuthConsentAction({
   try {
     const authCore = await import("@/lib/auth/core");
     const authApi = authCore.authApi;
-    const betterAuthInstance = Object.hasOwn(authCore, "betterAuthInstance")
-      ? authCore.betterAuthInstance
-      : undefined;
     const consentUrl = new URL("/api/auth/oauth2/consent", request.url);
     const body = {
       accept,
       scope,
       oauth_query: oauthQuery,
     };
-    try {
-      if (typeof betterAuthInstance?.handler === "function") {
-        const response = await betterAuthInstance.handler(
-          new Request(consentUrl, {
-            method: "POST",
-            headers,
-            body: JSON.stringify(body),
-          }),
-        );
-        const payload = (await response
-          .clone()
-          .json()
-          .catch(() => null)) as {
-          redirect_uri?: string;
-          redirectURI?: string;
-          url?: string;
-        } | null;
-        redirectTarget =
-          response.headers.get("location") ??
-          payload?.redirect_uri ??
-          payload?.redirectURI ??
-          payload?.url;
-      }
-    } catch {
-      redirectTarget = undefined;
-    }
-    if (!redirectTarget) {
-      const payload = await asOAuthProviderApi(authApi).oauth2Consent({
-        asResponse: false,
+    const payload = await asOAuthProviderApi(authApi).oauth2Consent({
+      asResponse: false,
+      headers,
+      request: new Request(consentUrl, {
+        method: "POST",
         headers,
-        request: new Request(consentUrl, {
-          method: "POST",
-          headers,
-        }),
-        body,
-      });
-      redirectTarget =
-        payload?.redirect_uri ?? payload?.redirectURI ?? payload?.url;
-    }
+      }),
+      body,
+    });
+    redirectTarget =
+      payload?.redirect_uri ?? payload?.redirectURI ?? payload?.url;
   } catch {
     redirectTarget = undefined;
   }


### PR DESCRIPTION
## Summary

Fix the OAuth consent action so it calls the Better Auth OAuth provider API directly and uses the structured callback redirect payload.

## Root Cause

The SvelteKit consent action first called the generic Better Auth HTTP handler and accepted any `Location` header as success. On Cloudflare, that handler can return a signed same-origin `/oauth/authorize` URL, which refreshes the consent page instead of redirecting the CLI browser flow to the localhost callback.

## Impact

After clicking Allow, CLI OAuth login should redirect directly to the registered loopback callback with an authorization code instead of requiring repeated clicks or page refreshes.

## Validation

- `bunx vitest run tests/unit/oauth-consent-action.test.ts`
- `bunx biome check src/features/oauth/server/oauth-consent-action.ts`
- `bun run build`
- Manual local E2E Worker flow: CLI login against `http://127.0.0.1:3000`; browser consent POST returned `303` to `http://localhost:<port>/callback` with `code`; CLI completed login.
- Authenticated local CLI `todo` command returned todos successfully.
