### PR TITLE
fix(oauth): consent authorize fallback

### DIFF
--- a/src/features/oauth/server/oauth-consent-action.ts
+++ b/src/features/oauth/server/oauth-consent-action.ts
@@ -3,6 +3,21 @@ import { isTrustedAuthOrigin } from "@/lib/auth/auth-origins";
 import { asOAuthProviderApi } from "@/lib/oauth/provider-api";
 import { parseOAuthConsentForm } from "./oauth-authorize-form";
 
+const OAUTH_SIGNED_QUERY_KEYS = new Set(["sig", "exp", "ba_iat", "ba_pl"]);
+
+type OAuthAuthorizeApi = {
+  oauth2Authorize(input: {
+    asResponse?: false;
+    headers: Headers;
+    request: Request;
+    query: Record<string, string>;
+  }): Promise<{
+    redirect_uri?: string;
+    redirectURI?: string;
+    url?: string;
+  }>;
+};
+
 function assertTrustedCookieRequestOrigin(request: Request) {
   const headers = request.headers;
   if (!headers.has("cookie")) return;
@@ -11,6 +26,43 @@ function assertTrustedCookieRequestOrigin(request: Request) {
   if (!origin || origin === "null" || !isTrustedAuthOrigin(origin)) {
     throw error(403, "Invalid origin");
   }
+}
+
+function redirectPayloadTarget(payload: {
+  redirect_uri?: string;
+  redirectURI?: string;
+  url?: string;
+}) {
+  return payload.redirect_uri ?? payload.redirectURI ?? payload.url;
+}
+
+function asOAuthAuthorizeApi(api: unknown): OAuthAuthorizeApi | null {
+  if (!api || typeof api !== "object") return null;
+  const authorize = (api as { oauth2Authorize?: unknown }).oauth2Authorize;
+  if (typeof authorize !== "function") return null;
+  return {
+    oauth2Authorize: authorize.bind(
+      api,
+    ) as OAuthAuthorizeApi["oauth2Authorize"],
+  };
+}
+
+function isOAuthAuthorizePageRedirect(target: string, requestUrl: string) {
+  try {
+    const url = new URL(target, requestUrl);
+    const requestOrigin = new URL(requestUrl).origin;
+    return url.origin === requestOrigin && url.pathname === "/oauth/authorize";
+  } catch {
+    return false;
+  }
+}
+
+function oauthAuthorizeQueryFromRedirect(target: string, requestUrl: string) {
+  const url = new URL(target, requestUrl);
+  for (const key of OAUTH_SIGNED_QUERY_KEYS) {
+    url.searchParams.delete(key);
+  }
+  return Object.fromEntries(url.searchParams.entries());
 }
 
 export async function submitOAuthConsentAction({
@@ -46,8 +98,31 @@ export async function submitOAuthConsentAction({
       }),
       body,
     });
-    redirectTarget =
-      payload?.redirect_uri ?? payload?.redirectURI ?? payload?.url;
+    redirectTarget = redirectPayloadTarget(payload);
+    if (
+      redirectTarget &&
+      isOAuthAuthorizePageRedirect(redirectTarget, request.url)
+    ) {
+      const authorizeApi = asOAuthAuthorizeApi(authApi);
+      const authorizeQuery = oauthAuthorizeQueryFromRedirect(
+        redirectTarget,
+        request.url,
+      );
+      const authorizeUrl = new URL("/api/auth/oauth2/authorize", request.url);
+      authorizeUrl.search = new URLSearchParams(authorizeQuery).toString();
+      const authorizePayload = await authorizeApi?.oauth2Authorize({
+        asResponse: false,
+        headers,
+        request: new Request(authorizeUrl, {
+          method: "GET",
+          headers,
+        }),
+        query: authorizeQuery,
+      });
+      redirectTarget = authorizePayload
+        ? redirectPayloadTarget(authorizePayload)
+        : undefined;
+    }
   } catch {
     redirectTarget = undefined;
   }


### PR DESCRIPTION
## Summary

- Handle provider consent responses that point back to the app consent page by explicitly completing the OAuth authorize step.
- Strip Better Auth signed transient query parameters before re-running the provider authorize API.
- Keep the existing consent failure redirect if the provider APIs do not return a usable callback URL.

## Root Cause

After consent, the provider can return an intermediate same-origin `/oauth/authorize?...&sig=...` URL instead of the final client callback. The SvelteKit consent action treated any returned URL as final, so the CLI browser flow refreshed the consent page instead of redirecting to `localhost` with an auth code.

## Validation

- `bunx biome check src/features/oauth/server/oauth-consent-action.ts`
- `bunx vitest run tests/unit/oauth-consent-action.test.ts`
- `bun run build`
- Local debug Worker E2E: CLI `auth login --verbose`, Playwright clicked debug login and Allow once, consent POST returned 303 to localhost callback with `code`, then CLI completed login.
- Local authenticated CLI E2E: `life-ustc --server http://127.0.0.1:3000 todo` returned 6 debug todos using the token from that login.
