### PR TITLE
chore(oauth): consent authorize redirect

### DIFF
--- a/src/features/oauth/server/oauth-consent-action.ts
+++ b/src/features/oauth/server/oauth-consent-action.ts
@@ -4,6 +4,7 @@ import { asOAuthProviderApi } from "@/lib/oauth/provider-api";
 import { parseOAuthConsentForm } from "./oauth-authorize-form";
 
 const OAUTH_SIGNED_QUERY_KEYS = new Set(["sig", "exp", "ba_iat", "ba_pl"]);
+const OAUTH_AUTHORIZE_RETRY_DELAYS_MS = [100, 250, 500, 1000, 2000];
 
 type OAuthAuthorizeApi = {
   oauth2Authorize(input: {
@@ -65,6 +66,76 @@ function oauthAuthorizeQueryFromRedirect(target: string, requestUrl: string) {
   return Object.fromEntries(url.searchParams.entries());
 }
 
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function requestOAuthAuthorizeTarget({
+  authorizeApi,
+  authorizeQuery,
+  headers,
+  requestUrl,
+}: {
+  authorizeApi: OAuthAuthorizeApi;
+  authorizeQuery: Record<string, string>;
+  headers: Headers;
+  requestUrl: string;
+}) {
+  const authorizeHeaders = new Headers(headers);
+  authorizeHeaders.delete("content-type");
+  const authorizeUrl = new URL("/api/auth/oauth2/authorize", requestUrl);
+  authorizeUrl.search = new URLSearchParams(authorizeQuery).toString();
+  const authorizePayload = await authorizeApi.oauth2Authorize({
+    asResponse: false,
+    headers: authorizeHeaders,
+    request: new Request(authorizeUrl, {
+      method: "GET",
+      headers: authorizeHeaders,
+    }),
+    query: authorizeQuery,
+  });
+  return redirectPayloadTarget(authorizePayload);
+}
+
+async function resolveAuthorizeRedirectAfterConsent({
+  authApi,
+  headers,
+  requestUrl,
+  redirectTarget,
+}: {
+  authApi: unknown;
+  headers: Headers;
+  requestUrl: string;
+  redirectTarget: string;
+}) {
+  if (!isOAuthAuthorizePageRedirect(redirectTarget, requestUrl)) {
+    return redirectTarget;
+  }
+
+  const authorizeApi = asOAuthAuthorizeApi(authApi);
+  if (!authorizeApi) return undefined;
+
+  const authorizeQuery = oauthAuthorizeQueryFromRedirect(
+    redirectTarget,
+    requestUrl,
+  );
+  for (const delayMs of OAUTH_AUTHORIZE_RETRY_DELAYS_MS) {
+    await delay(delayMs);
+    const nextTarget = await requestOAuthAuthorizeTarget({
+      authorizeApi,
+      authorizeQuery,
+      headers,
+      requestUrl,
+    });
+    if (!nextTarget) continue;
+    if (!isOAuthAuthorizePageRedirect(nextTarget, requestUrl)) {
+      return nextTarget;
+    }
+  }
+
+  return undefined;
+}
+
 export async function submitOAuthConsentAction({
   request,
 }: {
@@ -99,29 +170,13 @@ export async function submitOAuthConsentAction({
       body,
     });
     redirectTarget = redirectPayloadTarget(payload);
-    if (
-      redirectTarget &&
-      isOAuthAuthorizePageRedirect(redirectTarget, request.url)
-    ) {
-      const authorizeApi = asOAuthAuthorizeApi(authApi);
-      const authorizeQuery = oauthAuthorizeQueryFromRedirect(
-        redirectTarget,
-        request.url,
-      );
-      const authorizeUrl = new URL("/api/auth/oauth2/authorize", request.url);
-      authorizeUrl.search = new URLSearchParams(authorizeQuery).toString();
-      const authorizePayload = await authorizeApi?.oauth2Authorize({
-        asResponse: false,
+    if (redirectTarget) {
+      redirectTarget = await resolveAuthorizeRedirectAfterConsent({
+        authApi,
         headers,
-        request: new Request(authorizeUrl, {
-          method: "GET",
-          headers,
-        }),
-        query: authorizeQuery,
+        requestUrl: request.url,
+        redirectTarget,
       });
-      redirectTarget = authorizePayload
-        ? redirectPayloadTarget(authorizePayload)
-        : undefined;
     }
   } catch {
     redirectTarget = undefined;


### PR DESCRIPTION
## Summary

- Retry the provider authorize step with bounded backoff when a successful consent response points back to the consent page.
- Strip Better Auth signed transient query parameters before each retry.
- Treat an unresolved same-page consent redirect as `consent_failed` instead of refreshing the disabled Allow button page.

## Root Cause

Production persists the OAuth consent, but the immediate same-request authorize read can still return another signed `/oauth/authorize` consent URL. A later authorize request for the same client does redirect to the CLI callback with `code`, so the issue is read-after-write visibility/timing rather than missing session or invalid consent.

## Validation

- `bunx biome check src/features/oauth/server/oauth-consent-action.ts`
- `bunx vitest run tests/unit/oauth-consent-action.test.ts`
- `bun run build`
- Local debug Worker E2E: CLI `auth login --verbose`, Playwright clicked debug login and Allow once, consent POST returned 303 to localhost callback with `code`, then CLI completed login.
- Local authenticated CLI E2E: `life-ustc --server http://127.0.0.1:3000 todo` returned 6 debug todos using the token from that login.
- Production diagnosis before this patch: after a failed first Allow click, a later request to the same authorize URL redirected to localhost with `code`, confirming consent persisted but was not visible inside the first same-request authorize attempt.
