### PR TITLE
feat(mcp): OpenAI tool descriptors

### DIFF
--- a/docs/contracts/mcp.json
+++ b/docs/contracts/mcp.json
@@ -17,7 +17,8 @@
     "resource-bound-access-token": "MCP transport requests must present a resource-bound Bearer token for /api/mcp. JWT access tokens minted with the canonical MCP resource are accepted; opaque tokens without a resource indicator are rejected. Omitted-resource refresh grants are normalized to MCP only when the stored grant includes MCP-compatible feature scopes and the canonical MCP resource approval.",
     "transport-observability": "MCP transport handling emits production-safe structured request/response logs and Cloudflare Analytics Engine datapoints with JSON-RPC method summaries, tool names, argument keys, auth/origin phase, status, duration, and registered tool count; it never logs bearer tokens, cookies, or tool argument values.",
     "flexible-date-inputs": "Date and datetime parameters on MCP tools accept ISO 8601 with timezone offset (2026-05-01T08:00:00+08:00), bare date strings (2026-05-01, treated as UTC midnight for @db.Date columns), or timezone-less datetimes (2026-05-01T08:00:00, interpreted as Asia/Shanghai). Invalid strings produce a descriptive error response rather than a validation rejection.",
-    "time-override": "Time-sensitive tools (get_my_7days_timeline, get_upcoming_deadlines, get_my_overview, get_next_buses) accept an optional atTime parameter to anchor their internal clock to a caller-supplied moment instead of the server clock, enabling reproducible queries and future-scenario planning."
+    "time-override": "Time-sensitive tools (get_my_7days_timeline, get_upcoming_deadlines, get_my_overview, get_next_buses) accept an optional atTime parameter to anchor their internal clock to a caller-supplied moment instead of the server clock, enabling reproducible queries and future-scenario planning.",
+    "openai-compatible-descriptors": "Every registered tool advertises a human title, MCP annotations for read-only/destructive/open-world hints, and _meta.securitySchemes with the OAuth feature scopes required for that tool. Tool results expose object payloads as structuredContent while retaining text-formatted JSON for compatibility."
   },
   "capabilities": {
     "protocol-endpoint": {
@@ -178,7 +179,10 @@
           "Homework tools",
           "Section tools",
           "Tool name",
+          "Tool title",
           "Tool description",
+          "Tool annotations",
+          "OAuth security schemes",
           "Input schema",
           "Preferred tool for common prompts"
         ]

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -9,12 +9,26 @@ import { registerMyDataTools } from "@/lib/mcp/tools/my-data-tools";
 import { registerProfileTools } from "@/lib/mcp/tools/profile-tools";
 import { registerSectionDataTools } from "@/lib/mcp/tools/section-data-tools";
 import { registerUploadTools } from "@/lib/mcp/tools/upload-tools";
+import { installMcpToolDescriptorDefaults } from "./tool-descriptors";
+
+const SERVER_INSTRUCTIONS = [
+  "Use get_my_dashboard or get_my_overview before fanning out into narrower personal tools.",
+  "Use search_courses, search_sections, search_teachers, list_bus_routes, or list_dashboard_links to discover stable IDs before ID-based calls.",
+  "Mutation tools change Life@USTC user or collaborative data; summarize the intended change and ask for user confirmation before calling them.",
+].join(" ");
 
 export function createMcpServer() {
-  const server = new McpServer({
-    name: "life-ustc-mcp",
-    version: "1.0.0",
-  });
+  const server = new McpServer(
+    {
+      name: "life-ustc-mcp",
+      version: "1.0.0",
+    },
+    {
+      instructions: SERVER_INSTRUCTIONS,
+    },
+  );
+
+  installMcpToolDescriptorDefaults(server);
 
   registerBusTools(server);
   registerCommentTools(server);

--- a/src/lib/mcp/tool-descriptors.ts
+++ b/src/lib/mcp/tool-descriptors.ts
@@ -1,0 +1,104 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { PUBLIC_REST_SCOPES } from "@/lib/oauth/scope-registry";
+import { getRequiredMcpScopes } from "./tool-scopes";
+
+type ToolSecurityScheme = {
+  type: "oauth2";
+  scopes: string[];
+};
+
+type ToolDescriptorDefaults = {
+  title: string;
+  annotations: ToolAnnotations;
+  _meta: {
+    securitySchemes: ToolSecurityScheme[];
+  };
+};
+
+const OPEN_WORLD_WRITE_TOOLS = new Set([
+  "add_comment_reaction",
+  "create_comment",
+  "create_homework_on_section",
+  "delete_homework_on_section",
+  "delete_own_comment",
+  "remove_comment_reaction",
+  "update_homework_on_section",
+  "update_own_comment",
+  "upsert_description",
+]);
+
+const DESTRUCTIVE_WRITE_PREFIXES = [
+  "delete_",
+  "remove_",
+  "rename_",
+  "save_",
+  "set_",
+  "unsubscribe_",
+  "update_",
+  "upsert_",
+];
+
+function humanizeToolName(name: string) {
+  return name
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function isWriteScope(scope: string) {
+  return scope.endsWith(":write");
+}
+
+function isDestructiveWriteTool(name: string) {
+  return DESTRUCTIVE_WRITE_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
+export function getMcpToolDescriptorDefaults(
+  name: string,
+): ToolDescriptorDefaults {
+  const requiredScopes = getRequiredMcpScopes(name);
+  const scopes =
+    requiredScopes.length > 0 ? requiredScopes : [...PUBLIC_REST_SCOPES];
+  const isWrite = scopes.some(isWriteScope);
+  const title = humanizeToolName(name);
+
+  return {
+    title,
+    annotations: {
+      title,
+      readOnlyHint: !isWrite,
+      destructiveHint: isWrite && isDestructiveWriteTool(name),
+      openWorldHint: isWrite && OPEN_WORLD_WRITE_TOOLS.has(name),
+    },
+    _meta: {
+      securitySchemes: [{ type: "oauth2", scopes }],
+    },
+  };
+}
+
+export function installMcpToolDescriptorDefaults(server: McpServer) {
+  const registerTool = server.registerTool.bind(server);
+
+  server.registerTool = ((name, config, callback) => {
+    const defaults = getMcpToolDescriptorDefaults(name);
+    return registerTool(
+      name,
+      {
+        ...config,
+        title: config.title ?? defaults.title,
+        annotations: {
+          ...defaults.annotations,
+          ...config.annotations,
+        },
+        _meta: {
+          ...defaults._meta,
+          ...config._meta,
+          securitySchemes:
+            config._meta?.securitySchemes ?? defaults._meta.securitySchemes,
+        },
+      },
+      callback,
+    );
+  }) as typeof server.registerTool;
+}

--- a/src/lib/mcp/tools/helper-results.ts
+++ b/src/lib/mcp/tools/helper-results.ts
@@ -62,11 +62,15 @@ export function jsonToolResult(
       : mode === "summary"
         ? summarizeMcpPayload(value)
         : compactMcpPayload(value);
+  const serializedPayload = serializeDatesDeep(payload);
   return {
+    ...(isRecord(serializedPayload)
+      ? { structuredContent: serializedPayload }
+      : {}),
     content: [
       {
         type: "text" as const,
-        text: JSON.stringify(serializeDatesDeep(payload), null, 2),
+        text: JSON.stringify(serializedPayload, null, 2),
       },
     ],
   };

--- a/tests/unit/mcp-tool-descriptors.test.ts
+++ b/tests/unit/mcp-tool-descriptors.test.ts
@@ -1,0 +1,81 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { createMcpServer } from "@/lib/mcp/server";
+import { restReadScope, restWriteScope } from "@/lib/oauth/constants";
+
+async function listTools() {
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const mcpServer = createMcpServer();
+  const client = new Client({
+    name: "unit-test-client",
+    version: "1.0.0",
+  });
+
+  await mcpServer.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  try {
+    return await client.listTools();
+  } finally {
+    await client.close();
+    await mcpServer.close();
+  }
+}
+
+describe("MCP tool descriptors", () => {
+  it("exposes OpenAI-compatible auth metadata and read annotations", async () => {
+    const result = await listTools();
+    const tool = result.tools.find((item) => item.name === "list_my_todos");
+
+    expect(tool).toMatchObject({
+      title: "List My Todos",
+      annotations: {
+        title: "List My Todos",
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      _meta: {
+        securitySchemes: [{ type: "oauth2", scopes: [restReadScope("todo")] }],
+      },
+    });
+  });
+
+  it("marks personal overwrite tools as closed-world writes", async () => {
+    const result = await listTools();
+    const tool = result.tools.find((item) => item.name === "update_my_todo");
+
+    expect(tool).toMatchObject({
+      title: "Update My Todo",
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: false,
+      },
+      _meta: {
+        securitySchemes: [{ type: "oauth2", scopes: [restWriteScope("todo")] }],
+      },
+    });
+  });
+
+  it("marks collaborative publish tools as open-world writes", async () => {
+    const result = await listTools();
+    const tool = result.tools.find((item) => item.name === "create_comment");
+
+    expect(tool).toMatchObject({
+      title: "Create Comment",
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+      _meta: {
+        securitySchemes: [
+          { type: "oauth2", scopes: [restWriteScope("comment")] },
+        ],
+      },
+    });
+  });
+});

--- a/tests/unit/mcp-tool-helpers.test.ts
+++ b/tests/unit/mcp-tool-helpers.test.ts
@@ -19,24 +19,24 @@ function parseToolText(result: ReturnType<typeof jsonToolResult>) {
 
 describe("jsonToolResult summary 模式", () => {
   it("保留分页总数，同时报告返回和采样项", () => {
-    const result = parseToolText(
-      jsonToolResult(
-        {
-          data: Array.from({ length: 12 }, (_, index) => ({
-            id: index + 1,
-            title: `Item ${index + 1}`,
-          })),
-          pagination: {
-            page: 2,
-            pageSize: 12,
-            total: 53,
-            totalPages: 5,
-          },
+    const rawResult = jsonToolResult(
+      {
+        data: Array.from({ length: 12 }, (_, index) => ({
+          id: index + 1,
+          title: `Item ${index + 1}`,
+        })),
+        pagination: {
+          page: 2,
+          pageSize: 12,
+          total: 53,
+          totalPages: 5,
         },
-        { mode: "summary" },
-      ),
+      },
+      { mode: "summary" },
     );
+    const result = parseToolText(rawResult);
 
+    expect(rawResult.structuredContent).toEqual(result);
     expect(result.pagination).toEqual({
       page: 2,
       pageSize: 12,


### PR DESCRIPTION
## Summary
- Add centralized MCP tool descriptor defaults for human titles, read/write/destructive/open-world annotations, and OpenAI-compatible `_meta.securitySchemes` derived from existing feature scopes.
- Add server instructions to guide broad discovery first and require confirmation before mutation tools.
- Include object payloads as `structuredContent` while preserving text JSON responses for existing clients.
- Update the MCP contract docs and add focused descriptor/structured result coverage.

## Verification
- `bunx vitest run tests/unit/mcp-tool-descriptors.test.ts tests/unit/mcp-tool-helpers.test.ts tests/unit/mcp-tool-scopes.test.ts`
- `bunx vitest run tests/unit/mcp-tool-descriptors.test.ts tests/unit/mcp-tool-helpers.test.ts tests/unit/mcp-tool-scopes.test.ts tests/unit/mcp-auth.test.ts tests/unit/oauth-discovery-metadata.test.ts tests/unit/mcp-observability.test.ts tests/unit/mcp-request-logging.test.ts tests/unit/mcp-urls.test.ts`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx biome check src/lib/mcp/server.ts src/lib/mcp/tool-descriptors.ts src/lib/mcp/tools/helper-results.ts tests/unit/mcp-tool-descriptors.test.ts tests/unit/mcp-tool-helpers.test.ts docs/contracts/mcp.json`
- `DATABASE_URL=postgresql://unit:unit@127.0.0.1:5432/unit bun run build`

## Notes
- The implementation follows OpenAI Apps SDK guidance for tool descriptors, annotations, `_meta.securitySchemes`, and structured tool results while preserving MCP SDK behavior.