### PR TITLE
feat(ops): add database recovery gate

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -26,7 +26,7 @@ Keep Bun versions aligned with:
 - Docker is only for local infra, CI service containers, and the static loader image; do not add app-serving Docker jobs.
 - Keep workflow YAML as orchestration. Reusable check, test, and seed sequences live in `$life-ustc-dev-loop`.
 - Never commit secrets
-- Production database writers share the `production-database-writes` concurrency group and bind the externally protected `production` environment.
+- Production database writers share the `production-database-writes` concurrency group with `queue: max`, retaining up to 100 pending runs in FIFO order, and bind the externally protected `production` environment.
 - Recovery drills use the separate `database-recovery` environment and only its ephemeral isolated-database secrets. They do not prove provider backup or PITR configuration; follow `docs/runbooks/database-recovery.md`.
 - `copilot-setup-steps.yml` must keep a direct job named exactly `copilot-setup-steps`; inline `runs-on`, `permissions`, `services`, `timeout-minutes`, and `steps` instead of delegating the job through a reusable workflow.
 - When changing Copilot setup, run it through `workflow_dispatch` or a PR check. If setup fails, Copilot can still start from the partially prepared environment, so setup logs are part of the verification evidence.

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -9,6 +9,7 @@ CI/CD pipelines.
 | CI | push to main, PR to any branch | Default verification, MCP integration, Worker E2E artifact build, E2E shards |
 | DB-backed Bun job | workflow_call | Reusable Postgres-backed Bun job |
 | DB migrate deploy | successful CI completion on main, or manual | Production Prisma migrate deploy |
+| Recovery Drill Verify | manual | Isolated restore migration and aggregate integrity verification |
 | Copilot Setup Steps | manual or setup workflow changes | Copilot bootstrap validation |
 | Release | successful CI completion on main | Semantic release |
 
@@ -25,6 +26,8 @@ Keep Bun versions aligned with:
 - Docker is only for local infra, CI service containers, and the static loader image; do not add app-serving Docker jobs.
 - Keep workflow YAML as orchestration. Reusable check, test, and seed sequences live in `$life-ustc-dev-loop`.
 - Never commit secrets
+- Production database writers share the `production-database-writes` concurrency group and bind the externally protected `production` environment.
+- Recovery drills use the separate `database-recovery` environment and only its ephemeral isolated-database secrets. They do not prove provider backup or PITR configuration; follow `docs/runbooks/database-recovery.md`.
 - `copilot-setup-steps.yml` must keep a direct job named exactly `copilot-setup-steps`; inline `runs-on`, `permissions`, `services`, `timeout-minutes`, and `steps` instead of delegating the job through a reusable workflow.
 - When changing Copilot setup, run it through `workflow_dispatch` or a PR check. If setup fails, Copilot can still start from the partially prepared environment, so setup logs are part of the verification evidence.
 

--- a/.github/workflows/db-migrate-deploy.yml
+++ b/.github/workflows/db-migrate-deploy.yml
@@ -11,13 +11,14 @@ on:
       - main
 
 concurrency:
-  group: db-migrate-deploy
+  group: production-database-writes
   cancel-in-progress: false
 
 jobs:
   migrate:
     name: Deploy Prisma migrations
     runs-on: ubuntu-latest
+    environment: production
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&

--- a/.github/workflows/db-migrate-deploy.yml
+++ b/.github/workflows/db-migrate-deploy.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: production-database-writes
-  cancel-in-progress: false
+  queue: max
 
 jobs:
   migrate:

--- a/.github/workflows/recovery-drill-verify.yml
+++ b/.github/workflows/recovery-drill-verify.yml
@@ -1,0 +1,95 @@
+name: Recovery Drill Verify
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate-ref:
+        description: "Exact commit to migrate and verify against the isolated restore"
+        required: true
+        type: string
+      restore-point-utc:
+        description: "Provider restore point in UTC; evidence metadata only"
+        required: true
+        type: string
+
+concurrency:
+  group: database-recovery-drill
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify isolated database restore
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: database-recovery
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.candidate-ref }}
+
+      - name: Setup Bun environment
+        uses: ./.github/actions/setup-bun-env
+
+      - name: Generate recovery verifier client
+        env:
+          DATABASE_URL: postgresql://recovery-generate.invalid/life_ustc
+        run: bun run db:generate
+
+      - name: Verify isolated restore baseline
+        env:
+          RECOVERY_DATABASE_URL: ${{ secrets.RECOVERY_DATABASE_URL }}
+          RECOVERY_DRILL_GUARD: ${{ secrets.RECOVERY_DRILL_GUARD }}
+        run: |
+          set -euo pipefail
+          bun run scripts/verify-restored-database.ts \
+            > "$RUNNER_TEMP/recovery-before.json"
+
+      - name: Deploy candidate migrations to isolated restore
+        env:
+          DATABASE_URL: ${{ secrets.RECOVERY_DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          if ! bun run db:migrate:deploy \
+            > "$RUNNER_TEMP/recovery-migrate.log" 2>&1; then
+            echo "::error::Recovery database migration failed; connection details are suppressed."
+            exit 1
+          fi
+          rm -f "$RUNNER_TEMP/recovery-migrate.log"
+          echo "Recovery database migrations completed."
+
+      - name: Verify isolated restore after migration
+        env:
+          RECOVERY_DATABASE_URL: ${{ secrets.RECOVERY_DATABASE_URL }}
+          RECOVERY_DRILL_GUARD: ${{ secrets.RECOVERY_DRILL_GUARD }}
+        run: |
+          set -euo pipefail
+          bun run scripts/verify-restored-database.ts \
+            > "$RUNNER_TEMP/recovery-after.json"
+          jq -e --slurp '.[0].counts == .[1].counts' \
+            "$RUNNER_TEMP/recovery-before.json" \
+            "$RUNNER_TEMP/recovery-after.json" \
+            > /dev/null
+
+      - name: Report aggregate recovery checks
+        if: always()
+        run: |
+          {
+            echo "## Recovery Drill Aggregate Verification"
+            if [ -f "$RUNNER_TEMP/recovery-before.json" ]; then
+              echo "### Before candidate migration"
+              echo '```json'
+              cat "$RUNNER_TEMP/recovery-before.json"
+              echo '```'
+            fi
+            if [ -f "$RUNNER_TEMP/recovery-after.json" ]; then
+              echo "### After candidate migration"
+              echo '```json'
+              cat "$RUNNER_TEMP/recovery-after.json"
+              echo '```'
+            fi
+            echo
+            echo "This verifies only the isolated database aggregates. Provider backup, PITR, RPO, and RTO evidence remain operator-owned."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/recovery-drill-verify.yml
+++ b/.github/workflows/recovery-drill-verify.yml
@@ -25,10 +25,43 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Validate immutable recovery evidence
+        id: evidence
+        env:
+          CANDIDATE_REF: ${{ inputs.candidate-ref }}
+          RESTORE_POINT_UTC: ${{ inputs.restore-point-utc }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$CANDIDATE_REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::candidate-ref must be a full 40-character commit SHA."
+            exit 1
+          fi
+          if [[ ! "$RESTORE_POINT_UTC" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+            echo "::error::restore-point-utc must use YYYY-MM-DDTHH:MM:SSZ."
+            exit 1
+          fi
+          parsed_restore_point="$(date -u -d "$RESTORE_POINT_UTC" '+%Y-%m-%dT%H:%M:%SZ')"
+          if [ "$parsed_restore_point" != "$RESTORE_POINT_UTC" ]; then
+            echo "::error::restore-point-utc is not a valid UTC timestamp."
+            exit 1
+          fi
+          echo "candidate-sha=${CANDIDATE_REF,,}" >> "$GITHUB_OUTPUT"
+          echo "restore-point-utc=$RESTORE_POINT_UTC" >> "$GITHUB_OUTPUT"
+
       - name: Checkout candidate
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.candidate-ref }}
+          ref: ${{ steps.evidence.outputs.candidate-sha }}
+
+      - name: Confirm checked out candidate
+        env:
+          CANDIDATE_SHA: ${{ steps.evidence.outputs.candidate-sha }}
+        run: |
+          set -euo pipefail
+          if [ "$(git rev-parse HEAD)" != "$CANDIDATE_SHA" ]; then
+            echo "::error::Checked out commit does not match the reviewed candidate SHA."
+            exit 1
+          fi
 
       - name: Setup Bun environment
         uses: ./.github/actions/setup-bun-env
@@ -68,16 +101,26 @@ jobs:
           set -euo pipefail
           bun run scripts/verify-restored-database.ts \
             > "$RUNNER_TEMP/recovery-after.json"
-          jq -e --slurp '.[0].counts == .[1].counts' \
-            "$RUNNER_TEMP/recovery-before.json" \
-            "$RUNNER_TEMP/recovery-after.json" \
-            > /dev/null
+          if ! jq -e --slurp '.[0].counts == .[1].counts' \
+              "$RUNNER_TEMP/recovery-before.json" \
+              "$RUNNER_TEMP/recovery-after.json" \
+              > /dev/null; then
+            echo "::error::Allowlisted aggregate counts changed during the candidate migration."
+            exit 1
+          fi
 
       - name: Report aggregate recovery checks
         if: always()
+        env:
+          CANDIDATE_SHA: ${{ steps.evidence.outputs.candidate-sha }}
+          RESTORE_POINT_UTC: ${{ steps.evidence.outputs.restore-point-utc }}
         run: |
           {
             echo "## Recovery Drill Aggregate Verification"
+            if [ -n "$CANDIDATE_SHA" ] && [ -n "$RESTORE_POINT_UTC" ]; then
+              echo "Candidate SHA: \`$CANDIDATE_SHA\`"
+              echo "Restore point (UTC): \`$RESTORE_POINT_UTC\`"
+            fi
             if [ -f "$RUNNER_TEMP/recovery-before.json" ]; then
               echo "### Before candidate migration"
               echo '```json'

--- a/.github/workflows/static-sync.yml
+++ b/.github/workflows/static-sync.yml
@@ -12,13 +12,14 @@ on:
         type: boolean
 
 concurrency:
-  group: static-sync
+  group: production-database-writes
   cancel-in-progress: false
 
 jobs:
   sync:
     name: Sync static snapshot to production database
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 150
     permissions:
       contents: read

--- a/.github/workflows/static-sync.yml
+++ b/.github/workflows/static-sync.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: production-database-writes
-  cancel-in-progress: false
+  queue: max
 
 jobs:
   sync:

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ is the project map: start here, then follow the closest source of truth.
 ## Major Docs
 
 - [.agents/skills](../.agents/skills/) - checked-in reusable agent workflows.
+- [Database recovery runbook](runbooks/database-recovery.md) - provider evidence, isolated restore verification, RPO/RTO, and rollback gate.
 - [docs/AGENTS.md](AGENTS.md) - documentation editing rules.
 - [docs/contracts/AGENTS.md](contracts/AGENTS.md) - contract JSON workflow and validation.
 - [docs/contracts.schema.json](contracts.schema.json) - schema for contract files.

--- a/docs/runbooks/database-recovery.md
+++ b/docs/runbooks/database-recovery.md
@@ -1,0 +1,130 @@
+# Database Recovery
+
+This runbook is the repository-side recovery gate for production database
+changes such as the stale Section lifecycle migration in
+[Issue #468](https://github.com/Life-USTC/server/issues/468). It does not prove
+that backups or point-in-time recovery (PITR) exist. Provider-side evidence and
+a successful isolated restore drill are required before
+[Issue #471](https://github.com/Life-USTC/server/issues/471) can be closed.
+
+## Hard Gate
+
+Do not merge a production database change while its recovery prerequisite is
+open. A successful CI run on `main` automatically starts DB Migrate Deploy, and
+Static Sync also deploys migrations before its scheduled or manual import.
+
+The repository can verify an isolated restored database. It cannot:
+
+- identify the PostgreSQL provider from `DATABASE_URL` or Cloudflare Hyperdrive;
+- enable provider backups or PITR;
+- create a provider restore point;
+- prove retention, the recoverable window, RPO, or RTO;
+- replace an operator-owned rollback decision.
+
+## Evidence Record
+
+Record the following without credentials, connection strings, database names,
+personal data, comment bodies, or description contents:
+
+| Field | Required evidence |
+|---|---|
+| Provider and resource | Provider name plus a non-sensitive project/cluster alias |
+| Operational owner | Accountable team or role and the operator for this change |
+| Backup policy | Enabled state, retention, and provider evidence timestamp |
+| PITR window | Earliest and latest recoverable timestamps |
+| RPO | Declared target and the restore point selected for this change |
+| RTO | Declared target and measured restore-to-verification duration |
+| Candidate | Exact commit, migration name, and static snapshot SHA-256 when applicable |
+| Restore point | Provider snapshot reference or PITR timestamp created immediately before the window |
+| Drill | Recovery workflow run plus non-sensitive aggregate results |
+| Decision | Roll forward, reversible backfill rollback, or provider restore, with the decision owner |
+
+Provider screenshots or console links may remain in an access-controlled
+operations system. Link that evidence from the issue instead of copying secrets
+or production data into GitHub.
+
+## One-Time GitHub Setup
+
+GitHub environment protection is configured outside this repository.
+
+1. Configure required reviewers for the existing `production` environment.
+2. Create a separate `database-recovery` environment with required reviewers.
+3. Add only these environment secrets to `database-recovery`:
+   - `RECOVERY_DATABASE_URL`: an ephemeral connection to the isolated restore,
+     never production.
+   - `RECOVERY_DRILL_GUARD`: a new opaque marker for this drill. It is not a
+     provider credential.
+4. Do not add `DATABASE_URL`, a provider API token, or production credentials to
+   `database-recovery`.
+
+Referencing an environment does not make it protected by itself. Verify the
+review rules before relying on either gate.
+
+## Restore Drill
+
+1. Freeze the candidate commit and migration set. Record the exact static
+   snapshot hash when the change imports static data.
+2. Pause or coordinate all production database writers for the maintenance
+   window. DB Migrate Deploy and Static Sync share the
+   `production-database-writes` concurrency group, but GitHub concurrency is not
+   a replacement for an operator-owned maintenance window.
+3. Ask the provider to create a restore point immediately before the change.
+   Record its UTC timestamp and the current recoverable window.
+4. Restore that point into an isolated database with no application traffic.
+   Use a new role and short-lived credentials.
+5. Mark only the isolated database with the opaque value stored in
+   `RECOVERY_DRILL_GUARD`:
+
+   ```sql
+   COMMENT ON DATABASE "<isolated-database-name>"
+   IS 'life-ustc-recovery-drill:<opaque-marker>';
+   ```
+
+   Never put a URL, credential, provider resource ID, or personal data in the
+   comment. Never set this marker on production.
+6. Manually run **Recovery Drill Verify** with the frozen candidate ref. The
+   workflow:
+   - refuses to continue unless the database comment matches the environment
+     marker;
+   - collects a read-only aggregate baseline;
+   - deploys the candidate migrations to the isolated restore;
+   - repeats the read-only checks;
+   - fails if any allowlisted count changes or any orphan violation is nonzero;
+   - writes only aggregate JSON to the job summary and uploads no artifact.
+7. Record provider restore start, database-ready, migration-complete, and
+   verification-complete timestamps. Compare measured recovery time with the
+   declared RTO and the selected restore point with the declared RPO.
+8. Link the provider evidence and workflow run from #471. Keep #471 open if any
+   provider fact, integrity check, RPO, RTO, or rollback owner is missing.
+
+The verifier covers aggregate counts for Sections, Comments, Descriptions,
+Homeworks, user-to-Section calendar subscriptions, Schedules, Exams, and
+teacher relations. It reports only counts and orphan violations; it never
+selects user fields or content.
+
+## Production Rollout
+
+After #471 is complete:
+
+1. Approve the production environment only for the frozen candidate.
+2. Record before counts and confirm the provider restore point is still within
+   the PITR window.
+3. Apply the migration and reversible backfill.
+4. Confirm no Section or child row was hard-deleted and run the documented
+   after-count checks.
+5. Confirm that re-importing a Section clears retirement as specified by #468.
+
+## Rollback Decision
+
+- If the database is healthy and only lifecycle flags are wrong, stop the
+  importer and use the reviewed reversible backfill to clear the flags. Prefer
+  this over a whole-database restore.
+- If rows or relationships were destructively corrupted, stop all writers,
+  record the failure timestamp, and invoke the provider restore procedure.
+  Account explicitly for writes after the selected restore point.
+- The operational owner decides whether measured data loss and recovery time
+  remain within RPO/RTO. GitHub Actions must not make that decision.
+
+Do not upload `pg_dump`, production query results, or restore images as GitHub
+artifacts. A local or CI PostgreSQL test proves migration mechanics only; it is
+not provider PITR evidence.

--- a/docs/runbooks/database-recovery.md
+++ b/docs/runbooks/database-recovery.md
@@ -49,6 +49,8 @@ GitHub environment protection is configured outside this repository.
 
 1. Configure required reviewers for the existing `production` environment.
 2. Create a separate `database-recovery` environment with required reviewers.
+   A reviewer must confirm that the supplied full 40-character commit SHA is
+   the reviewed candidate before approving the job.
 3. Add only these environment secrets to `database-recovery`:
    - `RECOVERY_DATABASE_URL`: an ephemeral connection to the isolated restore,
      never production.
@@ -82,7 +84,9 @@ review rules before relying on either gate.
 
    Never put a URL, credential, provider resource ID, or personal data in the
    comment. Never set this marker on production.
-6. Manually run **Recovery Drill Verify** with the frozen candidate ref. The
+6. Manually run **Recovery Drill Verify** with the frozen candidate's full
+   40-character commit SHA and a valid `YYYY-MM-DDTHH:MM:SSZ` restore point.
+   Branches, tags, and abbreviated SHAs are rejected. The
    workflow:
    - refuses to continue unless the database comment matches the environment
      marker;

--- a/docs/runbooks/database-recovery.md
+++ b/docs/runbooks/database-recovery.md
@@ -68,8 +68,10 @@ review rules before relying on either gate.
    snapshot hash when the change imports static data.
 2. Pause or coordinate all production database writers for the maintenance
    window. DB Migrate Deploy and Static Sync share the
-   `production-database-writes` concurrency group, but GitHub concurrency is not
-   a replacement for an operator-owned maintenance window.
+   `production-database-writes` concurrency group. Its `queue: max` setting
+   retains up to 100 pending runs in FIFO order instead of replacing an older
+   pending migration with a newer sync. GitHub concurrency is still not a
+   replacement for an operator-owned maintenance window.
 3. Ask the provider to create a restore point immediately before the change.
    Record its UTC timestamp and the current recoverable window.
 4. Restore that point into an isolated database with no application traffic.

--- a/scripts/verify-restored-database.ts
+++ b/scripts/verify-restored-database.ts
@@ -1,0 +1,389 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "../src/generated/prisma-node/client";
+
+const GUARD_PREFIX = "life-ustc-recovery-drill:";
+const GUARD_VALUE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{15,127}$/;
+
+const COUNT_KEYS = [
+  "sections",
+  "comments",
+  "descriptions",
+  "homeworks",
+  "calendarSubscriptions",
+  "schedules",
+  "exams",
+  "sectionTeachers",
+  "teacherAssignments",
+  "sectionTeacherLinks",
+  "scheduleTeacherLinks",
+] as const;
+
+const VIOLATION_KEYS = [
+  "sectionsWithoutCourse",
+  "sectionsWithoutSemester",
+  "commentsWithInvalidTargetCount",
+  "commentsWithMissingTarget",
+  "descriptionsWithInvalidTargetCount",
+  "descriptionsWithMissingTarget",
+  "homeworksWithoutSection",
+  "calendarSubscriptionsWithoutSection",
+  "calendarSubscriptionsWithoutUser",
+  "schedulesWithoutSection",
+  "schedulesWithoutGroup",
+  "examsWithoutSection",
+  "sectionTeachersWithoutSection",
+  "sectionTeachersWithoutTeacher",
+  "teacherAssignmentsWithoutSection",
+  "teacherAssignmentsWithoutTeacher",
+  "sectionTeacherLinksWithoutSection",
+  "sectionTeacherLinksWithoutTeacher",
+  "scheduleTeacherLinksWithoutSchedule",
+  "scheduleTeacherLinksWithoutTeacher",
+] as const;
+
+type CountKey = (typeof COUNT_KEYS)[number];
+type ViolationKey = (typeof VIOLATION_KEYS)[number];
+type AggregateRow = Record<string, bigint | number | string | null | undefined>;
+
+export type RecoveryVerificationReport = {
+  schemaVersion: 1;
+  checkedAt: string;
+  guardVerified: true;
+  counts: Record<CountKey, number>;
+  violations: Record<ViolationKey, number>;
+  ok: boolean;
+};
+
+export type RecoveryQueryClient = {
+  $executeRawUnsafe(query: string, ...values: unknown[]): Promise<number>;
+  $queryRawUnsafe<T = unknown>(query: string, ...values: unknown[]): Promise<T>;
+};
+
+export type RecoveryDatabaseClient = {
+  $transaction<T>(
+    operation: (transaction: RecoveryQueryClient) => Promise<T>,
+    options?: {
+      isolationLevel?: "RepeatableRead";
+      maxWait?: number;
+      timeout?: number;
+    },
+  ): Promise<T>;
+  $disconnect(): Promise<void>;
+};
+
+export class RecoveryVerificationError extends Error {
+  constructor(
+    readonly code:
+      | "CONFIGURATION_MISSING"
+      | "GUARD_INVALID"
+      | "GUARD_MISMATCH"
+      | "INTEGRITY_VIOLATIONS",
+  ) {
+    super(code);
+    this.name = "RecoveryVerificationError";
+  }
+}
+
+const GUARD_QUERY = `
+  SELECT shobj_description(database.oid, 'pg_database') AS "guard"
+  FROM pg_database AS database
+  WHERE database.datname = current_database()
+`;
+
+const COUNTS_QUERY = `
+  SELECT
+    (SELECT COUNT(*)::text FROM "Section") AS "sections",
+    (SELECT COUNT(*)::text FROM "Comment") AS "comments",
+    (SELECT COUNT(*)::text FROM "Description") AS "descriptions",
+    (SELECT COUNT(*)::text FROM "Homework") AS "homeworks",
+    (SELECT COUNT(*)::text FROM "_UserCalendarSections") AS "calendarSubscriptions",
+    (SELECT COUNT(*)::text FROM "Schedule") AS "schedules",
+    (SELECT COUNT(*)::text FROM "Exam") AS "exams",
+    (SELECT COUNT(*)::text FROM "SectionTeacher") AS "sectionTeachers",
+    (SELECT COUNT(*)::text FROM "TeacherAssignment") AS "teacherAssignments",
+    (SELECT COUNT(*)::text FROM "_SectionTeachers") AS "sectionTeacherLinks",
+    (SELECT COUNT(*)::text FROM "_ScheduleTeachers") AS "scheduleTeacherLinks"
+`;
+
+const VIOLATIONS_QUERY = `
+  SELECT
+    (
+      SELECT COUNT(*)::text
+      FROM "Section" AS section
+      LEFT JOIN "Course" AS course ON course.id = section."courseId"
+      WHERE course.id IS NULL
+    ) AS "sectionsWithoutCourse",
+    (
+      SELECT COUNT(*)::text
+      FROM "Section" AS section
+      LEFT JOIN "Semester" AS semester ON semester.id = section."semesterId"
+      WHERE section."semesterId" IS NOT NULL AND semester.id IS NULL
+    ) AS "sectionsWithoutSemester",
+    (
+      SELECT COUNT(*)::text
+      FROM "Comment"
+      WHERE num_nonnulls(
+        "sectionId",
+        "courseId",
+        "teacherId",
+        "sectionTeacherId",
+        "homeworkId"
+      ) <> 1
+    ) AS "commentsWithInvalidTargetCount",
+    (
+      SELECT COUNT(*)::text
+      FROM "Comment" AS comment
+      LEFT JOIN "Section" AS section ON section.id = comment."sectionId"
+      LEFT JOIN "Course" AS course ON course.id = comment."courseId"
+      LEFT JOIN "Teacher" AS teacher ON teacher.id = comment."teacherId"
+      LEFT JOIN "SectionTeacher" AS section_teacher
+        ON section_teacher.id = comment."sectionTeacherId"
+      LEFT JOIN "Homework" AS homework ON homework.id = comment."homeworkId"
+      WHERE
+        (comment."sectionId" IS NOT NULL AND section.id IS NULL)
+        OR (comment."courseId" IS NOT NULL AND course.id IS NULL)
+        OR (comment."teacherId" IS NOT NULL AND teacher.id IS NULL)
+        OR (
+          comment."sectionTeacherId" IS NOT NULL
+          AND section_teacher.id IS NULL
+        )
+        OR (comment."homeworkId" IS NOT NULL AND homework.id IS NULL)
+    ) AS "commentsWithMissingTarget",
+    (
+      SELECT COUNT(*)::text
+      FROM "Description"
+      WHERE num_nonnulls(
+        "sectionId",
+        "courseId",
+        "teacherId",
+        "homeworkId"
+      ) <> 1
+    ) AS "descriptionsWithInvalidTargetCount",
+    (
+      SELECT COUNT(*)::text
+      FROM "Description" AS description
+      LEFT JOIN "Section" AS section ON section.id = description."sectionId"
+      LEFT JOIN "Course" AS course ON course.id = description."courseId"
+      LEFT JOIN "Teacher" AS teacher ON teacher.id = description."teacherId"
+      LEFT JOIN "Homework" AS homework ON homework.id = description."homeworkId"
+      WHERE
+        (description."sectionId" IS NOT NULL AND section.id IS NULL)
+        OR (description."courseId" IS NOT NULL AND course.id IS NULL)
+        OR (description."teacherId" IS NOT NULL AND teacher.id IS NULL)
+        OR (description."homeworkId" IS NOT NULL AND homework.id IS NULL)
+    ) AS "descriptionsWithMissingTarget",
+    (
+      SELECT COUNT(*)::text
+      FROM "Homework" AS homework
+      LEFT JOIN "Section" AS section ON section.id = homework."sectionId"
+      WHERE section.id IS NULL
+    ) AS "homeworksWithoutSection",
+    (
+      SELECT COUNT(*)::text
+      FROM "_UserCalendarSections" AS subscription
+      LEFT JOIN "Section" AS section ON section.id = subscription."A"
+      WHERE section.id IS NULL
+    ) AS "calendarSubscriptionsWithoutSection",
+    (
+      SELECT COUNT(*)::text
+      FROM "_UserCalendarSections" AS subscription
+      LEFT JOIN "User" AS app_user ON app_user.id = subscription."B"
+      WHERE app_user.id IS NULL
+    ) AS "calendarSubscriptionsWithoutUser",
+    (
+      SELECT COUNT(*)::text
+      FROM "Schedule" AS schedule
+      LEFT JOIN "Section" AS section ON section.id = schedule."sectionId"
+      WHERE section.id IS NULL
+    ) AS "schedulesWithoutSection",
+    (
+      SELECT COUNT(*)::text
+      FROM "Schedule" AS schedule
+      LEFT JOIN "ScheduleGroup" AS schedule_group
+        ON schedule_group.id = schedule."scheduleGroupId"
+      WHERE schedule_group.id IS NULL
+    ) AS "schedulesWithoutGroup",
+    (
+      SELECT COUNT(*)::text
+      FROM "Exam" AS exam
+      LEFT JOIN "Section" AS section ON section.id = exam."sectionId"
+      WHERE section.id IS NULL
+    ) AS "examsWithoutSection",
+    (
+      SELECT COUNT(*)::text
+      FROM "SectionTeacher" AS section_teacher
+      LEFT JOIN "Section" AS section ON section.id = section_teacher."sectionId"
+      WHERE section.id IS NULL
+    ) AS "sectionTeachersWithoutSection",
+    (
+      SELECT COUNT(*)::text
+      FROM "SectionTeacher" AS section_teacher
+      LEFT JOIN "Teacher" AS teacher ON teacher.id = section_teacher."teacherId"
+      WHERE teacher.id IS NULL
+    ) AS "sectionTeachersWithoutTeacher",
+    (
+      SELECT COUNT(*)::text
+      FROM "TeacherAssignment" AS assignment
+      LEFT JOIN "Section" AS section ON section.id = assignment."sectionId"
+      WHERE section.id IS NULL
+    ) AS "teacherAssignmentsWithoutSection",
+    (
+      SELECT COUNT(*)::text
+      FROM "TeacherAssignment" AS assignment
+      LEFT JOIN "Teacher" AS teacher ON teacher.id = assignment."teacherId"
+      WHERE teacher.id IS NULL
+    ) AS "teacherAssignmentsWithoutTeacher",
+    (
+      SELECT COUNT(*)::text
+      FROM "_SectionTeachers" AS relation
+      LEFT JOIN "Section" AS section ON section.id = relation."A"
+      WHERE section.id IS NULL
+    ) AS "sectionTeacherLinksWithoutSection",
+    (
+      SELECT COUNT(*)::text
+      FROM "_SectionTeachers" AS relation
+      LEFT JOIN "Teacher" AS teacher ON teacher.id = relation."B"
+      WHERE teacher.id IS NULL
+    ) AS "sectionTeacherLinksWithoutTeacher",
+    (
+      SELECT COUNT(*)::text
+      FROM "_ScheduleTeachers" AS relation
+      LEFT JOIN "Schedule" AS schedule ON schedule.id = relation."A"
+      WHERE schedule.id IS NULL
+    ) AS "scheduleTeacherLinksWithoutSchedule",
+    (
+      SELECT COUNT(*)::text
+      FROM "_ScheduleTeachers" AS relation
+      LEFT JOIN "Teacher" AS teacher ON teacher.id = relation."B"
+      WHERE teacher.id IS NULL
+    ) AS "scheduleTeacherLinksWithoutTeacher"
+`;
+
+function requireGuardValue(value: string | undefined): string {
+  if (!value) {
+    throw new RecoveryVerificationError("CONFIGURATION_MISSING");
+  }
+  if (!GUARD_VALUE_PATTERN.test(value)) {
+    throw new RecoveryVerificationError("GUARD_INVALID");
+  }
+  return value;
+}
+
+export function expectedRecoveryGuard(value: string): string {
+  return `${GUARD_PREFIX}${requireGuardValue(value)}`;
+}
+
+function parseAggregateRow<const Keys extends readonly string[]>(
+  row: AggregateRow | undefined,
+  keys: Keys,
+): Record<Keys[number], number> {
+  if (!row) {
+    throw new Error("Aggregate query returned no rows");
+  }
+
+  return Object.fromEntries(
+    keys.map((key) => {
+      const rawValue = row[key];
+      const text = typeof rawValue === "bigint" ? `${rawValue}` : rawValue;
+      if (
+        (typeof text !== "string" && typeof text !== "number") ||
+        !/^\d+$/.test(`${text}`)
+      ) {
+        throw new Error("Aggregate query returned an invalid count");
+      }
+
+      const value = Number(text);
+      if (!Number.isSafeInteger(value)) {
+        throw new Error("Aggregate query returned an unsafe count");
+      }
+      return [key, value];
+    }),
+  ) as Record<Keys[number], number>;
+}
+
+async function assertRecoveryGuard(
+  transaction: RecoveryQueryClient,
+  guardValue: string,
+) {
+  const rows =
+    await transaction.$queryRawUnsafe<Array<{ guard: string | null }>>(
+      GUARD_QUERY,
+    );
+  if (rows[0]?.guard !== expectedRecoveryGuard(guardValue)) {
+    throw new RecoveryVerificationError("GUARD_MISMATCH");
+  }
+}
+
+export async function verifyRestoredDatabase(
+  database: RecoveryDatabaseClient,
+  guardValue: string | undefined,
+  now: () => Date = () => new Date(),
+): Promise<RecoveryVerificationReport> {
+  const requiredGuard = requireGuardValue(guardValue);
+
+  return database.$transaction(
+    async (transaction) => {
+      await transaction.$executeRawUnsafe("SET TRANSACTION READ ONLY");
+      await assertRecoveryGuard(transaction, requiredGuard);
+
+      const countRows =
+        await transaction.$queryRawUnsafe<AggregateRow[]>(COUNTS_QUERY);
+      const violationRows =
+        await transaction.$queryRawUnsafe<AggregateRow[]>(VIOLATIONS_QUERY);
+      const counts = parseAggregateRow(countRows[0], COUNT_KEYS);
+      const violations = parseAggregateRow(violationRows[0], VIOLATION_KEYS);
+
+      return {
+        schemaVersion: 1,
+        checkedAt: now().toISOString(),
+        guardVerified: true,
+        counts,
+        violations,
+        ok: Object.values(violations).every((value) => value === 0),
+      };
+    },
+    {
+      isolationLevel: "RepeatableRead",
+      maxWait: 10_000,
+      timeout: 120_000,
+    },
+  );
+}
+
+async function run() {
+  const connectionString = process.env.RECOVERY_DATABASE_URL;
+  if (!connectionString) {
+    throw new RecoveryVerificationError("CONFIGURATION_MISSING");
+  }
+
+  const database = new PrismaClient({
+    adapter: new PrismaPg({ connectionString }),
+  }) as unknown as RecoveryDatabaseClient;
+
+  try {
+    const report = await verifyRestoredDatabase(
+      database,
+      process.env.RECOVERY_DRILL_GUARD,
+    );
+    console.log(JSON.stringify(report, null, 2));
+    if (!report.ok) {
+      throw new RecoveryVerificationError("INTEGRITY_VIOLATIONS");
+    }
+  } finally {
+    await database.$disconnect();
+  }
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : null;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  run().catch((error: unknown) => {
+    const code =
+      error instanceof RecoveryVerificationError
+        ? error.code
+        : "UNEXPECTED_ERROR";
+    console.error(`Recovery database verification failed: ${code}`);
+    process.exitCode = 1;
+  });
+}

--- a/src/static-loader/cli.ts
+++ b/src/static-loader/cli.ts
@@ -15,10 +15,6 @@ function getEnv(name: string, defaultValue?: string): string {
   return value;
 }
 
-function maskDatabaseUrl(url: string): string {
-  return url.replace(/:\/\/([^:@]+)(:[^@]+)?@/, "://***@");
-}
-
 async function sha256File(path: string): Promise<string> {
   const hash = createHash("sha256");
   for await (const chunk of createReadStream(path)) {
@@ -28,7 +24,6 @@ async function sha256File(path: string): Promise<string> {
 }
 
 async function main() {
-  const databaseUrl = getEnv("DATABASE_URL");
   const snapshotPath = getEnv("STATIC_SNAPSHOT_PATH");
   const minSemester = parsePositiveIntegerSetting(
     "STATIC_LOADER_MIN_SEMESTER",
@@ -45,7 +40,6 @@ async function main() {
     throw new Error(`Snapshot not found: ${snapshotPath}`);
   }
 
-  console.log(`DATABASE_URL: ${maskDatabaseUrl(databaseUrl)}`);
   console.log(`snapshotPath: ${snapshotPath}`);
   console.log(`minSemester: ${minSemester}`);
   console.log(`dryRun: ${dryRun}`);

--- a/tests/integration/database-recovery-verifier.test.ts
+++ b/tests/integration/database-recovery-verifier.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  expectedRecoveryGuard,
+  type RecoveryDatabaseClient,
+  verifyRestoredDatabase,
+} from "../../scripts/verify-restored-database";
+import {
+  createTestPrisma,
+  disconnectTestPrisma,
+  type TestPrismaClient,
+} from "../shared/prisma";
+
+const GUARD = "integration-recovery-guard-20260718";
+
+function quoteIdentifier(value: string) {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function quoteLiteral(value: string) {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+describe("restored database verifier integration", () => {
+  let prisma: TestPrismaClient;
+
+  beforeAll(() => {
+    prisma = createTestPrisma();
+  });
+
+  afterAll(async () => {
+    await disconnectTestPrisma(prisma);
+  });
+
+  it("reads only aggregate integrity data after validating the database guard", async () => {
+    const rows = await prisma.$queryRawUnsafe<
+      Array<{ databaseName: string; previousComment: string | null }>
+    >(`
+      SELECT
+        current_database() AS "databaseName",
+        shobj_description(database.oid, 'pg_database') AS "previousComment"
+      FROM pg_database AS database
+      WHERE database.datname = current_database()
+    `);
+    const databaseName = rows[0]?.databaseName;
+    if (!databaseName) throw new Error("Test database name was not available");
+
+    await prisma.$executeRawUnsafe(
+      `COMMENT ON DATABASE ${quoteIdentifier(databaseName)} IS ${quoteLiteral(expectedRecoveryGuard(GUARD))}`,
+    );
+
+    try {
+      const report = await verifyRestoredDatabase(
+        prisma as unknown as RecoveryDatabaseClient,
+        GUARD,
+        () => new Date("2026-07-18T00:00:00.000Z"),
+      );
+
+      expect(report.guardVerified).toBe(true);
+      expect(report.ok).toBe(true);
+      expect(report.counts.sections).toBeGreaterThan(0);
+      expect(Object.values(report.violations)).toEqual(
+        expect.arrayContaining([0]),
+      );
+      expect(new Set(Object.values(report.violations))).toEqual(new Set([0]));
+    } finally {
+      const previousComment = rows[0]?.previousComment;
+      const restore = previousComment ? quoteLiteral(previousComment) : "NULL";
+      await prisma.$executeRawUnsafe(
+        `COMMENT ON DATABASE ${quoteIdentifier(databaseName)} IS ${restore}`,
+      );
+    }
+  });
+});

--- a/tests/unit/database-recovery-verifier.test.ts
+++ b/tests/unit/database-recovery-verifier.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  expectedRecoveryGuard,
+  type RecoveryDatabaseClient,
+  RecoveryVerificationError,
+  verifyRestoredDatabase,
+} from "../../scripts/verify-restored-database";
+
+const GUARD = "unit-recovery-guard-20260718";
+
+const counts = {
+  sections: "10",
+  comments: "3",
+  descriptions: "2",
+  homeworks: "1",
+  calendarSubscriptions: "4",
+  schedules: "12",
+  exams: "2",
+  sectionTeachers: "6",
+  teacherAssignments: "6",
+  sectionTeacherLinks: "6",
+  scheduleTeacherLinks: "8",
+};
+
+const violations = {
+  sectionsWithoutCourse: "0",
+  sectionsWithoutSemester: "0",
+  commentsWithInvalidTargetCount: "0",
+  commentsWithMissingTarget: "0",
+  descriptionsWithInvalidTargetCount: "0",
+  descriptionsWithMissingTarget: "0",
+  homeworksWithoutSection: "0",
+  calendarSubscriptionsWithoutSection: "0",
+  calendarSubscriptionsWithoutUser: "0",
+  schedulesWithoutSection: "0",
+  schedulesWithoutGroup: "0",
+  examsWithoutSection: "0",
+  sectionTeachersWithoutSection: "0",
+  sectionTeachersWithoutTeacher: "0",
+  teacherAssignmentsWithoutSection: "0",
+  teacherAssignmentsWithoutTeacher: "0",
+  sectionTeacherLinksWithoutSection: "0",
+  sectionTeacherLinksWithoutTeacher: "0",
+  scheduleTeacherLinksWithoutSchedule: "0",
+  scheduleTeacherLinksWithoutTeacher: "0",
+};
+
+function fakeDatabase({
+  guard = expectedRecoveryGuard(GUARD),
+  violationOverrides = {},
+}: {
+  guard?: string | null;
+  violationOverrides?: Partial<typeof violations>;
+} = {}) {
+  const statements: string[] = [];
+  const queries: string[] = [];
+  const rows = [
+    [{ guard }],
+    [counts],
+    [{ ...violations, ...violationOverrides }],
+  ];
+
+  const database = {
+    $transaction: async (
+      operation: Parameters<RecoveryDatabaseClient["$transaction"]>[0],
+    ) =>
+      operation({
+        $executeRawUnsafe: async (query) => {
+          statements.push(query);
+          return 0;
+        },
+        $queryRawUnsafe: async <T>(query: string) => {
+          queries.push(query);
+          return rows[queries.length - 1] as T;
+        },
+      }),
+    $disconnect: vi.fn(),
+  } as RecoveryDatabaseClient;
+
+  return { database, queries, statements };
+}
+
+describe("restored database verifier", () => {
+  it("checks the isolation guard before returning allowlisted aggregates", async () => {
+    const { database, queries, statements } = fakeDatabase();
+
+    const report = await verifyRestoredDatabase(
+      database,
+      GUARD,
+      () => new Date("2026-07-18T00:00:00.000Z"),
+    );
+
+    expect(statements).toEqual(["SET TRANSACTION READ ONLY"]);
+    expect(queries).toHaveLength(3);
+    expect(report).toEqual({
+      schemaVersion: 1,
+      checkedAt: "2026-07-18T00:00:00.000Z",
+      guardVerified: true,
+      counts: Object.fromEntries(
+        Object.entries(counts).map(([key, value]) => [key, Number(value)]),
+      ),
+      violations: Object.fromEntries(
+        Object.entries(violations).map(([key, value]) => [key, Number(value)]),
+      ),
+      ok: true,
+    });
+
+    const serialized = JSON.stringify(report);
+    expect(serialized).not.toContain(GUARD);
+    expect(serialized).not.toMatch(
+      /databaseName|connection|credential|host|url|userId|body|content/i,
+    );
+  });
+
+  it("fails closed before aggregate queries when the guard does not match", async () => {
+    const { database, queries } = fakeDatabase({ guard: null });
+
+    await expect(verifyRestoredDatabase(database, GUARD)).rejects.toMatchObject(
+      {
+        code: "GUARD_MISMATCH",
+      } satisfies Partial<RecoveryVerificationError>,
+    );
+    expect(queries).toHaveLength(1);
+  });
+
+  it.each([
+    undefined,
+    "",
+    "too-short",
+    "contains spaces here",
+  ])("rejects an absent or unsafe guard value", async (guard) => {
+    const { database, queries } = fakeDatabase();
+
+    await expect(
+      verifyRestoredDatabase(database, guard),
+    ).rejects.toBeInstanceOf(RecoveryVerificationError);
+    expect(queries).toHaveLength(0);
+  });
+
+  it("reports integrity violations without exposing row data", async () => {
+    const { database } = fakeDatabase({
+      violationOverrides: { homeworksWithoutSection: "2" },
+    });
+
+    const report = await verifyRestoredDatabase(database, GUARD);
+
+    expect(report.ok).toBe(false);
+    expect(report.violations.homeworksWithoutSection).toBe(2);
+  });
+});

--- a/tests/unit/database-recovery-workflow.test.ts
+++ b/tests/unit/database-recovery-workflow.test.ts
@@ -14,7 +14,8 @@ describe("database recovery workflow safety", () => {
 
     for (const source of [migrate, sync]) {
       expect(source).toContain("group: production-database-writes");
-      expect(source).toContain("cancel-in-progress: false");
+      expect(source).toContain("queue: max");
+      expect(source).not.toContain("cancel-in-progress");
       expect(source).toContain("environment: production");
     }
   });

--- a/tests/unit/database-recovery-workflow.test.ts
+++ b/tests/unit/database-recovery-workflow.test.ts
@@ -30,6 +30,14 @@ describe("database recovery workflow safety", () => {
     expect(workflow).not.toContain("secrets.DATABASE_URL");
     expect(workflow).not.toContain("upload-artifact");
     expect(workflow).not.toMatch(/provider.*token/i);
+    expect(workflow).toContain("^[0-9a-fA-F]{40}$");
+    expect(workflow).toContain(
+      "Allowlisted aggregate counts changed during the candidate migration.",
+    );
+    expect(
+      workflow.indexOf("Validate immutable recovery evidence"),
+    ).toBeLessThan(workflow.indexOf("Checkout candidate"));
+    expect(workflow).toContain("steps.evidence.outputs.restore-point-utc");
   });
 
   it("never logs a DATABASE_URL-derived value", async () => {

--- a/tests/unit/database-recovery-workflow.test.ts
+++ b/tests/unit/database-recovery-workflow.test.ts
@@ -1,0 +1,46 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+async function readRepoFile(path: string) {
+  return readFile(new URL(`../../${path}`, import.meta.url), "utf8");
+}
+
+describe("database recovery workflow safety", () => {
+  it("serializes production writers behind the production environment", async () => {
+    const [migrate, sync] = await Promise.all([
+      readRepoFile(".github/workflows/db-migrate-deploy.yml"),
+      readRepoFile(".github/workflows/static-sync.yml"),
+    ]);
+
+    for (const source of [migrate, sync]) {
+      expect(source).toContain("group: production-database-writes");
+      expect(source).toContain("cancel-in-progress: false");
+      expect(source).toContain("environment: production");
+    }
+  });
+
+  it("uses only isolated recovery secrets and uploads no artifacts", async () => {
+    const workflow = await readRepoFile(
+      ".github/workflows/recovery-drill-verify.yml",
+    );
+
+    expect(workflow).toContain("environment: database-recovery");
+    expect(workflow).toContain("secrets.RECOVERY_DATABASE_URL");
+    expect(workflow).toContain("secrets.RECOVERY_DRILL_GUARD");
+    expect(workflow).not.toContain("secrets.DATABASE_URL");
+    expect(workflow).not.toContain("upload-artifact");
+    expect(workflow).not.toMatch(/provider.*token/i);
+  });
+
+  it("never logs a DATABASE_URL-derived value", async () => {
+    const [staticLoader, verifier] = await Promise.all([
+      readRepoFile("src/static-loader/cli.ts"),
+      readRepoFile("scripts/verify-restored-database.ts"),
+    ]);
+
+    expect(staticLoader).not.toContain("maskDatabaseUrl");
+    expect(staticLoader).not.toMatch(/console\.log[^\n]*DATABASE_URL/);
+    expect(verifier).not.toContain("process.env.DATABASE_URL");
+    expect(verifier).not.toMatch(/console\.(log|error)[^\\n]*connectionString/);
+  });
+});

--- a/tsconfig.typecheck.operational.json
+++ b/tsconfig.typecheck.operational.json
@@ -6,6 +6,7 @@
   "include": [
     "playwright.config.ts",
     "prisma.config.ts",
+    "scripts/verify-restored-database.ts",
     "vitest.base.ts",
     "vitest.config.ts",
     "vitest.integration.config.ts",


### PR DESCRIPTION
## Goal

Add the repository-side recovery gate and isolated restore verifier required by #471, without claiming that provider backup or PITR evidence exists.

## Changes

- document the provider/PITR/RPO/RTO evidence and rollback runbook
- add a manual isolated-restore workflow that accepts only an immutable 40-character commit SHA
- fail closed unless an opaque database-comment guard matches, then run fixed read-only aggregate and orphan checks
- serialize DB Migrate Deploy and Static Sync in `production-database-writes` with `queue: max` and bind both to the `production` environment
- remove the Static Loader log derived from `DATABASE_URL`

## Verification

- unit: 184 files / 1101 tests
- integration: 28 files / 175 tests against local PostgreSQL
- all TypeScript projects, Svelte check, production build, Biome
- recovery workflow YAML parsed with `yq`; current actionlint 1.7.12 predates GitHub Actions `queue: max`
- independent review: no remaining P0/P1/P2; immutable ref, secret boundary, read-only transaction, output allowlist, and queue semantics audited

## Operational boundary

This PR is repository groundwork only. It does **not** prove provider backups/PITR, configure GitHub environment reviewers, connect to a recovery database, and leaves #471 open. Maintainers must still configure required reviewers for `production` and `database-recovery`, provide an isolated restore, run the drill, and attach non-sensitive provider evidence.

The additive storage migration from #473 was applied by scheduled Static Sync before cancellation; the loader/backfill/retirement steps were skipped. #468 behavior remains blocked.

Refs #471
Refs #468