### PR TITLE
refactor(db): route Todo through transaction-local user context

### DIFF
--- a/src/features/todos/server/todo-service.ts
+++ b/src/features/todos/server/todo-service.ts
@@ -81,15 +81,22 @@ function requireTodoUserId(where: Prisma.TodoWhereInput) {
   if (typeof where.userId !== "string" || !where.userId) {
     throw new Error("Todo queries require an explicit user ID");
   }
-  return where.userId;
+  return normalizeTodoUserId(where.userId);
+}
+
+function normalizeTodoUserId(userId: string) {
+  const normalized = userId.trim();
+  if (!normalized) throw new Error("Todo queries require an explicit user ID");
+  return normalized;
 }
 
 export async function createTodo(input: TodoCreateInput) {
-  return withUserDbContext(input.userId, () =>
+  const userId = normalizeTodoUserId(input.userId);
+  return withUserDbContext(userId, () =>
     prisma.todo.create({
       select: { id: true },
       data: {
-        userId: input.userId,
+        userId,
         title: input.title,
         content: input.content?.trim() || null,
         priority: input.priority ?? "medium",
@@ -124,9 +131,10 @@ export async function listTodoSnapshots(input: {
   take?: number;
   where: Prisma.TodoWhereInput;
 }) {
-  return withUserDbContext(requireTodoUserId(input.where), () =>
+  const userId = requireTodoUserId(input.where);
+  return withUserDbContext(userId, () =>
     prisma.todo.findMany({
-      where: input.where,
+      where: { ...input.where, userId },
       select: todoSnapshotSelect,
       orderBy: input.orderBy ?? todoListOrderBy,
       ...(input.take !== undefined && { take: input.take }),
@@ -157,9 +165,10 @@ export async function listDueTodoSamples(input: {
   take?: number;
   userId: string;
 }) {
-  return withUserDbContext(input.userId, () =>
+  const userId = normalizeTodoUserId(input.userId);
+  return withUserDbContext(userId, () =>
     prisma.todo.findMany({
-      where: buildDueTodoWhere(input),
+      where: buildDueTodoWhere({ ...input, userId }),
       select: todoDueSampleSelect,
       orderBy: todoDueDateOrderBy,
       ...(input.take !== undefined && { take: input.take }),
@@ -168,6 +177,7 @@ export async function listDueTodoSamples(input: {
 }
 
 export async function countIncompleteTodos(userId: string) {
+  userId = normalizeTodoUserId(userId);
   return withUserDbContext(userId, () =>
     prisma.todo.count({
       where: { userId, completed: false },
@@ -182,9 +192,10 @@ export async function countDueTodos(input: {
   includeDueAtTo?: boolean;
   userId: string;
 }) {
-  return withUserDbContext(input.userId, () =>
+  const userId = normalizeTodoUserId(input.userId);
+  return withUserDbContext(userId, () =>
     prisma.todo.count({
-      where: buildDueTodoWhere(input),
+      where: buildDueTodoWhere({ ...input, userId }),
     }),
   );
 }
@@ -196,6 +207,7 @@ function buildDueTodoWhere(input: {
   includeDueAtTo?: boolean;
   userId: string;
 }) {
+  const userId = normalizeTodoUserId(input.userId);
   const dueAt: Prisma.DateTimeNullableFilter = { not: null };
   if (input.dueAtFrom) dueAt.gte = input.dueAtFrom;
   if (input.dueAtTo) {
@@ -207,7 +219,7 @@ function buildDueTodoWhere(input: {
   }
 
   const where: Prisma.TodoWhereInput = {
-    userId: input.userId,
+    userId,
     dueAt,
   };
   if (input.completed !== undefined) where.completed = input.completed;
@@ -220,16 +232,17 @@ export async function listTodoSummary(input: {
   take?: number;
   userId: string;
 }) {
-  return withUserDbContext(input.userId, async () => {
+  const userId = normalizeTodoUserId(input.userId);
+  return withUserDbContext(userId, async () => {
     const now = input.now ?? new Date();
-    const where = buildTodoListWhere(input.userId, input.filters);
-    const incompleteCount = await countIncompleteTodos(input.userId);
+    const where = buildTodoListWhere(userId, input.filters);
+    const incompleteCount = await countIncompleteTodos(userId);
     const completedCount = await prisma.todo.count({
-      where: { userId: input.userId, completed: true },
+      where: { userId, completed: true },
     });
     const overdueCount = await prisma.todo.count({
       where: {
-        userId: input.userId,
+        userId,
         completed: false,
         dueAt: { lt: now },
       },
@@ -255,9 +268,10 @@ export async function listTodoPage(input: {
   };
   userId: string;
 }) {
-  const where = buildTodoListWhere(input.userId, input.filters);
+  const userId = normalizeTodoUserId(input.userId);
+  const where = buildTodoListWhere(userId, input.filters);
   const pagination = normalizePagination(input.pagination);
-  return withUserDbContext(input.userId, async () => {
+  return withUserDbContext(userId, async () => {
     const data = await prisma.todo.findMany({
       where,
       select: todoSnapshotSelect,
@@ -276,6 +290,7 @@ export async function listTodoPage(input: {
 }
 
 export async function requireOwnedTodo(id: string, userId: string) {
+  userId = normalizeTodoUserId(userId);
   return withUserDbContext(userId, async () => {
     const todo = await prisma.todo.findUnique({
       where: { id },
@@ -295,8 +310,9 @@ export async function updateOwnedTodo(input: {
   id: string;
   userId: string;
 }) {
-  return withUserDbContext(input.userId, async () => {
-    const ownership = await requireOwnedTodo(input.id, input.userId);
+  const userId = normalizeTodoUserId(input.userId);
+  return withUserDbContext(userId, async () => {
+    const ownership = await requireOwnedTodo(input.id, userId);
     if (!ownership.ok) return ownership;
 
     const updates = buildTodoMutationData(input.data);
@@ -314,6 +330,7 @@ export async function updateOwnedTodo(input: {
 }
 
 export async function deleteOwnedTodo(id: string, userId: string) {
+  userId = normalizeTodoUserId(userId);
   return withUserDbContext(userId, async () => {
     const deleted = await prisma.todo.deleteMany({ where: { id, userId } });
     if (deleted.count > 0) return { ok: true as const };

--- a/src/features/todos/server/todo-service.ts
+++ b/src/features/todos/server/todo-service.ts
@@ -1,6 +1,6 @@
 import type { Prisma, TodoPriority } from "@/generated/prisma/client";
+import { buildPaginatedResponse, normalizePagination } from "@/lib/api/helpers";
 import { prisma, withUserDbContext } from "@/lib/db/prisma";
-import { paginatedQuery } from "@/lib/query-pagination";
 
 export const todoSnapshotSelect = {
   id: true,
@@ -256,21 +256,23 @@ export async function listTodoPage(input: {
   userId: string;
 }) {
   const where = buildTodoListWhere(input.userId, input.filters);
-  return withUserDbContext(input.userId, () =>
-    paginatedQuery(
-      (skip, take) =>
-        prisma.todo.findMany({
-          where,
-          select: todoSnapshotSelect,
-          orderBy: todoListOrderBy,
-          skip,
-          take,
-        }),
-      () => prisma.todo.count({ where }),
-      input.pagination.page,
-      input.pagination.pageSize,
-    ),
-  );
+  const pagination = normalizePagination(input.pagination);
+  return withUserDbContext(input.userId, async () => {
+    const data = await prisma.todo.findMany({
+      where,
+      select: todoSnapshotSelect,
+      orderBy: todoListOrderBy,
+      skip: pagination.skip,
+      take: pagination.pageSize,
+    });
+    const total = await prisma.todo.count({ where });
+    return buildPaginatedResponse(
+      data,
+      pagination.page,
+      pagination.pageSize,
+      total,
+    );
+  });
 }
 
 export async function requireOwnedTodo(id: string, userId: string) {

--- a/src/features/todos/server/todo-service.ts
+++ b/src/features/todos/server/todo-service.ts
@@ -1,5 +1,5 @@
 import type { Prisma, TodoPriority } from "@/generated/prisma/client";
-import { prisma } from "@/lib/db/prisma";
+import { prisma, withUserDbContext } from "@/lib/db/prisma";
 import { paginatedQuery } from "@/lib/query-pagination";
 
 export const todoSnapshotSelect = {
@@ -77,17 +77,26 @@ export function buildTodoMutationData(input: TodoMutationDataInput) {
   return updates;
 }
 
+function requireTodoUserId(where: Prisma.TodoWhereInput) {
+  if (typeof where.userId !== "string" || !where.userId) {
+    throw new Error("Todo queries require an explicit user ID");
+  }
+  return where.userId;
+}
+
 export async function createTodo(input: TodoCreateInput) {
-  return prisma.todo.create({
-    select: { id: true },
-    data: {
-      userId: input.userId,
-      title: input.title,
-      content: input.content?.trim() || null,
-      priority: input.priority ?? "medium",
-      ...(input.dueAt !== undefined && { dueAt: input.dueAt }),
-    },
-  });
+  return withUserDbContext(input.userId, () =>
+    prisma.todo.create({
+      select: { id: true },
+      data: {
+        userId: input.userId,
+        title: input.title,
+        content: input.content?.trim() || null,
+        priority: input.priority ?? "medium",
+        ...(input.dueAt !== undefined && { dueAt: input.dueAt }),
+      },
+    }),
+  );
 }
 
 export async function listTodos(where: Prisma.TodoWhereInput) {
@@ -115,12 +124,14 @@ export async function listTodoSnapshots(input: {
   take?: number;
   where: Prisma.TodoWhereInput;
 }) {
-  return prisma.todo.findMany({
-    where: input.where,
-    select: todoSnapshotSelect,
-    orderBy: input.orderBy ?? todoListOrderBy,
-    ...(input.take !== undefined && { take: input.take }),
-  });
+  return withUserDbContext(requireTodoUserId(input.where), () =>
+    prisma.todo.findMany({
+      where: input.where,
+      select: todoSnapshotSelect,
+      orderBy: input.orderBy ?? todoListOrderBy,
+      ...(input.take !== undefined && { take: input.take }),
+    }),
+  );
 }
 
 export async function listDueTodoSnapshots(input: {
@@ -146,18 +157,22 @@ export async function listDueTodoSamples(input: {
   take?: number;
   userId: string;
 }) {
-  return prisma.todo.findMany({
-    where: buildDueTodoWhere(input),
-    select: todoDueSampleSelect,
-    orderBy: todoDueDateOrderBy,
-    ...(input.take !== undefined && { take: input.take }),
-  });
+  return withUserDbContext(input.userId, () =>
+    prisma.todo.findMany({
+      where: buildDueTodoWhere(input),
+      select: todoDueSampleSelect,
+      orderBy: todoDueDateOrderBy,
+      ...(input.take !== undefined && { take: input.take }),
+    }),
+  );
 }
 
 export async function countIncompleteTodos(userId: string) {
-  return prisma.todo.count({
-    where: { userId, completed: false },
-  });
+  return withUserDbContext(userId, () =>
+    prisma.todo.count({
+      where: { userId, completed: false },
+    }),
+  );
 }
 
 export async function countDueTodos(input: {
@@ -167,9 +182,11 @@ export async function countDueTodos(input: {
   includeDueAtTo?: boolean;
   userId: string;
 }) {
-  return prisma.todo.count({
-    where: buildDueTodoWhere(input),
-  });
+  return withUserDbContext(input.userId, () =>
+    prisma.todo.count({
+      where: buildDueTodoWhere(input),
+    }),
+  );
 }
 
 function buildDueTodoWhere(input: {
@@ -203,38 +220,34 @@ export async function listTodoSummary(input: {
   take?: number;
   userId: string;
 }) {
-  const now = input.now ?? new Date();
-  const where = buildTodoListWhere(input.userId, input.filters);
-  const [incompleteCount, completedCount, overdueCount, todos] =
-    await Promise.all([
-      countIncompleteTodos(input.userId),
-      prisma.todo.count({
-        where: { userId: input.userId, completed: true },
-      }),
-      prisma.todo.count({
-        where: {
-          userId: input.userId,
-          completed: false,
-          dueAt: { lt: now },
-        },
-      }),
-      listTodoSnapshots({
-        where,
-        take: input.take,
-      }),
-    ]);
+  return withUserDbContext(input.userId, async () => {
+    const now = input.now ?? new Date();
+    const where = buildTodoListWhere(input.userId, input.filters);
+    const incompleteCount = await countIncompleteTodos(input.userId);
+    const completedCount = await prisma.todo.count({
+      where: { userId: input.userId, completed: true },
+    });
+    const overdueCount = await prisma.todo.count({
+      where: {
+        userId: input.userId,
+        completed: false,
+        dueAt: { lt: now },
+      },
+    });
+    const todos = await listTodoSnapshots({ where, take: input.take });
 
-  return {
-    counts: {
-      incomplete: incompleteCount,
-      completed: completedCount,
-      overdue: overdueCount,
-    },
-    todos,
-  };
+    return {
+      counts: {
+        incomplete: incompleteCount,
+        completed: completedCount,
+        overdue: overdueCount,
+      },
+      todos,
+    };
+  });
 }
 
-export function listTodoPage(input: {
+export async function listTodoPage(input: {
   filters?: TodoListFilters;
   pagination: {
     page: number;
@@ -243,32 +256,36 @@ export function listTodoPage(input: {
   userId: string;
 }) {
   const where = buildTodoListWhere(input.userId, input.filters);
-  return paginatedQuery(
-    (skip, take) =>
-      prisma.todo.findMany({
-        where,
-        select: todoSnapshotSelect,
-        orderBy: todoListOrderBy,
-        skip,
-        take,
-      }),
-    () => prisma.todo.count({ where }),
-    input.pagination.page,
-    input.pagination.pageSize,
+  return withUserDbContext(input.userId, () =>
+    paginatedQuery(
+      (skip, take) =>
+        prisma.todo.findMany({
+          where,
+          select: todoSnapshotSelect,
+          orderBy: todoListOrderBy,
+          skip,
+          take,
+        }),
+      () => prisma.todo.count({ where }),
+      input.pagination.page,
+      input.pagination.pageSize,
+    ),
   );
 }
 
 export async function requireOwnedTodo(id: string, userId: string) {
-  const todo = await prisma.todo.findUnique({
-    where: { id },
-    select: { id: true, userId: true },
-  });
+  return withUserDbContext(userId, async () => {
+    const todo = await prisma.todo.findUnique({
+      where: { id },
+      select: { id: true, userId: true },
+    });
 
-  if (!todo) return { ok: false as const, error: "not_found" as const };
-  if (todo.userId !== userId) {
-    return { ok: false as const, error: "forbidden" as const };
-  }
-  return { ok: true as const, todo };
+    if (!todo) return { ok: false as const, error: "not_found" as const };
+    if (todo.userId !== userId) {
+      return { ok: false as const, error: "forbidden" as const };
+    }
+    return { ok: true as const, todo };
+  });
 }
 
 export async function updateOwnedTodo(input: {
@@ -276,33 +293,37 @@ export async function updateOwnedTodo(input: {
   id: string;
   userId: string;
 }) {
-  const ownership = await requireOwnedTodo(input.id, input.userId);
-  if (!ownership.ok) return ownership;
+  return withUserDbContext(input.userId, async () => {
+    const ownership = await requireOwnedTodo(input.id, input.userId);
+    if (!ownership.ok) return ownership;
 
-  const updates = buildTodoMutationData(input.data);
-  if (Object.keys(updates).length === 0) {
-    return { ok: false as const, error: "no_changes" as const };
-  }
+    const updates = buildTodoMutationData(input.data);
+    if (Object.keys(updates).length === 0) {
+      return { ok: false as const, error: "no_changes" as const };
+    }
 
-  const todo = await prisma.todo.update({
-    where: { id: input.id },
-    data: updates,
-    select: todoSnapshotSelect,
+    const todo = await prisma.todo.update({
+      where: { id: input.id },
+      data: updates,
+      select: todoSnapshotSelect,
+    });
+    return { ok: true as const, todo };
   });
-  return { ok: true as const, todo };
 }
 
 export async function deleteOwnedTodo(id: string, userId: string) {
-  const deleted = await prisma.todo.deleteMany({ where: { id, userId } });
-  if (deleted.count > 0) return { ok: true as const };
+  return withUserDbContext(userId, async () => {
+    const deleted = await prisma.todo.deleteMany({ where: { id, userId } });
+    if (deleted.count > 0) return { ok: true as const };
 
-  const todo = await prisma.todo.findUnique({
-    where: { id },
-    select: { id: true, userId: true },
+    const todo = await prisma.todo.findUnique({
+      where: { id },
+      select: { id: true, userId: true },
+    });
+    if (!todo) return { ok: false as const, error: "not_found" as const };
+    if (todo.userId !== userId) {
+      return { ok: false as const, error: "forbidden" as const };
+    }
+    return { ok: false as const, error: "not_found" as const };
   });
-  if (!todo) return { ok: false as const, error: "not_found" as const };
-  if (todo.userId !== userId) {
-    return { ok: false as const, error: "forbidden" as const };
-  }
-  return { ok: false as const, error: "not_found" as const };
 }

--- a/src/lib/db/prisma.ts
+++ b/src/lib/db/prisma.ts
@@ -7,6 +7,10 @@ import {
 import { localizedNamesExtension } from "@/lib/db/prisma-localized-names";
 import { createBasePrisma, logPrismaQuery } from "@/lib/db/prisma-query-events";
 import { shouldEnablePrismaQueryLogging } from "@/lib/db/prisma-query-logging";
+import {
+  getUserRlsTransactionClient,
+  runWithUserRlsContext,
+} from "@/lib/db/rls-context";
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
@@ -86,11 +90,20 @@ function getBasePrisma() {
 
 export const prisma = new Proxy({} as PrismaClient, {
   get(_target, property, receiver) {
-    const client = getBasePrisma();
+    const client = getUserRlsTransactionClient() ?? getBasePrisma();
     const value = Reflect.get(client, property, receiver);
     return typeof value === "function" ? value.bind(client) : value;
   },
 });
+
+export function withUserDbContext<T>(
+  userId: string,
+  action: (
+    tx: import("@/generated/prisma/client").Prisma.TransactionClient,
+  ) => Promise<T>,
+) {
+  return runWithUserRlsContext(getBasePrisma(), userId, action);
+}
 
 const _makeExtendedClient = (locale: string) =>
   prisma.$extends(localizedNamesExtension(locale));

--- a/src/lib/db/rls-context.ts
+++ b/src/lib/db/rls-context.ts
@@ -35,7 +35,7 @@ export async function runWithUserRlsContext<T>(
   }
 
   return client.$transaction(async (tx) => {
-    await tx.$executeRaw`SELECT set_config('app.user_id', ${normalizedUserId}, true)`;
+    await tx.$queryRaw`SELECT set_config('app.user_id', ${normalizedUserId}, true)`;
     return userRlsStorage.run({ tx, userId: normalizedUserId }, () =>
       action(tx),
     );

--- a/src/lib/db/rls-context.ts
+++ b/src/lib/db/rls-context.ts
@@ -1,0 +1,43 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { Prisma } from "@/generated/prisma/client";
+
+type UserRlsContext = {
+  tx: Prisma.TransactionClient;
+  userId: string;
+};
+
+type TransactionStarter = {
+  $transaction<T>(
+    action: (tx: Prisma.TransactionClient) => Promise<T>,
+  ): Promise<T>;
+};
+
+const userRlsStorage = new AsyncLocalStorage<UserRlsContext>();
+
+export function getUserRlsTransactionClient() {
+  return userRlsStorage.getStore()?.tx;
+}
+
+export async function runWithUserRlsContext<T>(
+  client: TransactionStarter,
+  userId: string,
+  action: (tx: Prisma.TransactionClient) => Promise<T>,
+) {
+  const normalizedUserId = userId.trim();
+  if (!normalizedUserId) throw new Error("RLS user ID is required");
+
+  const active = userRlsStorage.getStore();
+  if (active) {
+    if (active.userId !== normalizedUserId) {
+      throw new Error("Cannot change RLS user inside an active transaction");
+    }
+    return action(active.tx);
+  }
+
+  return client.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT set_config('app.user_id', ${normalizedUserId}, true)`;
+    return userRlsStorage.run({ tx, userId: normalizedUserId }, () =>
+      action(tx),
+    );
+  });
+}

--- a/tests/unit/rls-context.test.ts
+++ b/tests/unit/rls-context.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Prisma } from "@/generated/prisma/client";
+import {
+  getUserRlsTransactionClient,
+  runWithUserRlsContext,
+} from "@/lib/db/rls-context";
+
+function createClient() {
+  const tx = {
+    $executeRaw: vi.fn().mockResolvedValue(1),
+  } as unknown as Prisma.TransactionClient;
+  const client = {
+    $transaction: vi.fn(async (action) => action(tx)),
+  };
+  return { client, tx };
+}
+
+describe("user RLS context", () => {
+  it("sets transaction-local identity and exposes the same client", async () => {
+    const { client, tx } = createClient();
+    const result = await runWithUserRlsContext(
+      client,
+      " user-1 ",
+      async (current) => {
+        expect(current).toBe(tx);
+        expect(getUserRlsTransactionClient()).toBe(tx);
+        return "ok";
+      },
+    );
+
+    expect(result).toBe("ok");
+    expect(client.$transaction).toHaveBeenCalledOnce();
+    expect(tx.$executeRaw).toHaveBeenCalledOnce();
+    expect(getUserRlsTransactionClient()).toBeUndefined();
+  });
+
+  it("reuses a same-user context without nesting a transaction", async () => {
+    const { client } = createClient();
+    await runWithUserRlsContext(client, "user-1", async () => {
+      await runWithUserRlsContext(client, "user-1", async () => undefined);
+    });
+    expect(client.$transaction).toHaveBeenCalledOnce();
+  });
+
+  it("rejects identity changes inside an active transaction", async () => {
+    const { client } = createClient();
+    await expect(
+      runWithUserRlsContext(client, "user-1", () =>
+        runWithUserRlsContext(client, "user-2", async () => undefined),
+      ),
+    ).rejects.toThrow("Cannot change RLS user");
+  });
+});

--- a/tests/unit/rls-context.test.ts
+++ b/tests/unit/rls-context.test.ts
@@ -7,7 +7,7 @@ import {
 
 function createClient() {
   const tx = {
-    $executeRaw: vi.fn().mockResolvedValue(1),
+    $queryRaw: vi.fn().mockResolvedValue([{ set_config: "" }]),
   } as unknown as Prisma.TransactionClient;
   const client = {
     $transaction: vi.fn(async (action) => action(tx)),
@@ -30,7 +30,7 @@ describe("user RLS context", () => {
 
     expect(result).toBe("ok");
     expect(client.$transaction).toHaveBeenCalledOnce();
-    expect(tx.$executeRaw).toHaveBeenCalledOnce();
+    expect(tx.$queryRaw).toHaveBeenCalledOnce();
     expect(getUserRlsTransactionClient()).toBeUndefined();
   });
 

--- a/tests/unit/todo-service-delete.test.ts
+++ b/tests/unit/todo-service-delete.test.ts
@@ -1,18 +1,28 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { deleteOwnedTodo } from "@/features/todos/server/todo-service";
+import {
+  createTodo,
+  deleteOwnedTodo,
+} from "@/features/todos/server/todo-service";
 
-const { todoDeleteManyMock, todoFindUniqueMock, withUserDbContextMock } =
-  vi.hoisted(() => ({
-    todoDeleteManyMock: vi.fn(),
-    todoFindUniqueMock: vi.fn(),
-    withUserDbContextMock: vi.fn(
-      async (_userId: string, action: () => Promise<unknown>) => action(),
-    ),
-  }));
+const {
+  todoCreateMock,
+  todoDeleteManyMock,
+  todoFindUniqueMock,
+  withUserDbContextMock,
+} = vi.hoisted(() => ({
+  todoCreateMock: vi.fn(),
+  todoDeleteManyMock: vi.fn(),
+  todoFindUniqueMock: vi.fn(),
+  withUserDbContextMock: vi.fn(
+    async (_userId: string, action: (tx: unknown) => Promise<unknown>) =>
+      action({}),
+  ),
+}));
 
 vi.mock("@/lib/db/prisma", () => ({
   prisma: {
     todo: {
+      create: todoCreateMock,
       deleteMany: todoDeleteManyMock,
       findUnique: todoFindUniqueMock,
     },
@@ -23,6 +33,22 @@ vi.mock("@/lib/db/prisma", () => ({
 describe("deleteOwnedTodo", () => {
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("uses one normalized owner ID for context and writes", async () => {
+    todoCreateMock.mockResolvedValue({ id: "todo-1" });
+
+    await createTodo({ title: "Todo", userId: " user-1 " });
+
+    expect(withUserDbContextMock).toHaveBeenCalledWith(
+      "user-1",
+      expect.any(Function),
+    );
+    expect(todoCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ userId: "user-1" }),
+      }),
+    );
   });
 
   it("deletes by id and owner in one write", async () => {

--- a/tests/unit/todo-service-delete.test.ts
+++ b/tests/unit/todo-service-delete.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { deleteOwnedTodo } from "@/features/todos/server/todo-service";
 
-const { todoDeleteManyMock, todoFindUniqueMock } = vi.hoisted(() => ({
-  todoDeleteManyMock: vi.fn(),
-  todoFindUniqueMock: vi.fn(),
-}));
+const { todoDeleteManyMock, todoFindUniqueMock, withUserDbContextMock } =
+  vi.hoisted(() => ({
+    todoDeleteManyMock: vi.fn(),
+    todoFindUniqueMock: vi.fn(),
+    withUserDbContextMock: vi.fn(
+      async (_userId: string, action: () => Promise<unknown>) => action(),
+    ),
+  }));
 
 vi.mock("@/lib/db/prisma", () => ({
   prisma: {
@@ -13,6 +17,7 @@ vi.mock("@/lib/db/prisma", () => ({
       findUnique: todoFindUniqueMock,
     },
   },
+  withUserDbContext: withUserDbContextMock,
 }));
 
 describe("deleteOwnedTodo", () => {

--- a/tests/unit/viewer-page-services.test.ts
+++ b/tests/unit/viewer-page-services.test.ts
@@ -12,6 +12,7 @@ const {
   sectionFindManyMock,
   todoCountMock,
   todoFindManyMock,
+  withUserDbContextMock,
 } = vi.hoisted(() => ({
   examCountMock: vi.fn(),
   examFindManyMock: vi.fn(),
@@ -24,6 +25,9 @@ const {
   sectionFindManyMock: vi.fn(),
   todoCountMock: vi.fn(),
   todoFindManyMock: vi.fn(),
+  withUserDbContextMock: vi.fn(
+    async (_userId: string, action: () => Promise<unknown>) => action(),
+  ),
 }));
 
 const localizedPrisma = {
@@ -39,6 +43,7 @@ vi.mock("@/lib/db/prisma", () => ({
     comment: { groupBy: vi.fn() },
     todo: { count: todoCountMock, findMany: todoFindManyMock },
   },
+  withUserDbContext: withUserDbContextMock,
 }));
 
 describe("viewer page services", () => {

--- a/tests/unit/viewer-page-services.test.ts
+++ b/tests/unit/viewer-page-services.test.ts
@@ -26,7 +26,8 @@ const {
   todoCountMock: vi.fn(),
   todoFindManyMock: vi.fn(),
   withUserDbContextMock: vi.fn(
-    async (_userId: string, action: () => Promise<unknown>) => action(),
+    async (_userId: string, action: (tx: unknown) => Promise<unknown>) =>
+      action({}),
   ),
 }));
 


### PR DESCRIPTION
Part of #550. This is the deliberately inactive first half of the Todo RLS rollout. It deploys before the policy migration so there is no migration/Worker race window.

- adds `withUserDbContext(userId, action)` using an interactive Prisma transaction and transaction-local `set_config('app.user_id', ..., true)`
- routes all Todo reads/writes used by REST, GraphQL, MCP, dashboard, calendar and assistant projections through the exact transaction client via AsyncLocalStorage
- safely reuses same-user nested calls and rejects attempts to change identity inside an active transaction
- does not enable any PostgreSQL policy in this PR

This follows the Prisma/Hyperdrive constraints recorded in #550: no session-global `SET`, no Prisma extension that can escape the transaction, and no request-wide long transaction.

Verification:
- full unit suite: 235 files / 1,439 tests
- focused RLS context and Todo service tests
- application and test TypeScript
- separate local PostgreSQL activation rehearsal completed on the follow-up branch

After this is merged and deployed, a second PR will add the raw SQL Todo policy plus a dedicated non-owner / `NOBYPASSRLS` CI job.

<!-- project-relationship:start -->
## Project relationship

Part of #601.
<!-- project-relationship:end -->