### PR TITLE
feat(db): activate Todo row-level security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ jobs:
       database-name: life_ustc_integration
       job-phase: ci:integration
 
+  test-rls:
+    name: PostgreSQL RLS Isolation Test
+    needs: check
+    permissions:
+      contents: read
+    uses: ./.github/workflows/db-backed-bun-job.yml
+    with:
+      database-name: life_ustc_rls
+      job-phase: ci:rls
+
   build-e2e-artifacts:
     name: Build E2E artifacts
     needs: check

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -165,6 +165,7 @@ jobs:
               bun run app:prepare
               bun run db:migrate:deploy
               bunx prisma db seed
+              # Keep the RLS database setup idempotent like ci:integration.
               bunx prisma db seed
               PGPASSWORD=postgres psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
                 --command "CREATE ROLE life_ustc_runtime LOGIN PASSWORD 'runtime-test-password' NOINHERIT NOBYPASSRLS" \

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -165,13 +165,12 @@ jobs:
               bun run app:prepare
               bun run db:migrate:deploy
               bunx prisma db seed
-              PGPASSWORD=postgres psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
-              CREATE ROLE life_ustc_runtime LOGIN PASSWORD 'runtime-test-password' NOINHERIT NOBYPASSRLS;
-              GRANT CONNECT ON DATABASE "${{ inputs.database-name }}" TO life_ustc_runtime;
-              GRANT USAGE ON SCHEMA public TO life_ustc_runtime;
-              GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO life_ustc_runtime;
-              GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO life_ustc_runtime;
-              SQL
+              PGPASSWORD=postgres psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+                --command "CREATE ROLE life_ustc_runtime LOGIN PASSWORD 'runtime-test-password' NOINHERIT NOBYPASSRLS" \
+                --command 'GRANT CONNECT ON DATABASE "${{ inputs.database-name }}" TO life_ustc_runtime' \
+                --command 'GRANT USAGE ON SCHEMA public TO life_ustc_runtime' \
+                --command 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO life_ustc_runtime' \
+                --command 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO life_ustc_runtime'
               runtime_database_url="postgresql://life_ustc_runtime:runtime-test-password@127.0.0.1:5432/${{ inputs.database-name }}"
               DATABASE_URL="$runtime_database_url" bunx vitest run \
                 --config vitest.integration.config.ts \

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -168,11 +168,12 @@ jobs:
               # Keep the RLS database setup idempotent like ci:integration.
               bunx prisma db seed
               PGPASSWORD=postgres psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
-                --command "CREATE ROLE life_ustc_runtime LOGIN PASSWORD 'runtime-test-password' NOINHERIT NOBYPASSRLS" \
+                --command "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'life_ustc_runtime') THEN CREATE ROLE life_ustc_runtime; END IF; END \$\$" \
+                --command "ALTER ROLE life_ustc_runtime LOGIN PASSWORD 'runtime-test-password' NOINHERIT NOBYPASSRLS" \
                 --command 'GRANT CONNECT ON DATABASE "${{ inputs.database-name }}" TO life_ustc_runtime' \
                 --command 'GRANT USAGE ON SCHEMA public TO life_ustc_runtime' \
-                --command 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO life_ustc_runtime' \
-                --command 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO life_ustc_runtime'
+                --command 'GRANT SELECT ON TABLE "User" TO life_ustc_runtime' \
+                --command 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "Todo" TO life_ustc_runtime'
               runtime_database_url="postgresql://life_ustc_runtime:runtime-test-password@127.0.0.1:5432/${{ inputs.database-name }}"
               DATABASE_URL="$runtime_database_url" RLS_TEST_ENABLED=true bunx vitest run \
                 --config vitest.integration.config.ts \

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -165,6 +165,7 @@ jobs:
               bun run app:prepare
               bun run db:migrate:deploy
               bunx prisma db seed
+              bunx prisma db seed
               PGPASSWORD=postgres psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
                 --command "CREATE ROLE life_ustc_runtime LOGIN PASSWORD 'runtime-test-password' NOINHERIT NOBYPASSRLS" \
                 --command 'GRANT CONNECT ON DATABASE "${{ inputs.database-name }}" TO life_ustc_runtime' \
@@ -172,7 +173,7 @@ jobs:
                 --command 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO life_ustc_runtime' \
                 --command 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO life_ustc_runtime'
               runtime_database_url="postgresql://life_ustc_runtime:runtime-test-password@127.0.0.1:5432/${{ inputs.database-name }}"
-              DATABASE_URL="$runtime_database_url" bunx vitest run \
+              DATABASE_URL="$runtime_database_url" RLS_TEST_ENABLED=true bunx vitest run \
                 --config vitest.integration.config.ts \
                 tests/integration/todo-rls.test.ts
               ;;

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -111,7 +111,7 @@ jobs:
           install-playwright: ${{ inputs.install-playwright && 'true' || 'false' }}
 
       - name: Install PostgreSQL client
-        if: ${{ inputs.job-phase == 'ci:integration' || inputs.job-phase == 'ci:e2e:test' }}
+        if: ${{ inputs.job-phase == 'ci:integration' || inputs.job-phase == 'ci:rls' || inputs.job-phase == 'ci:e2e:test' }}
         shell: bash
         run: |
           sudo apt-get update
@@ -160,6 +160,22 @@ jobs:
               # The canonical scenario must be safe to load repeatedly.
               bunx prisma db seed
               bunx vitest run --config vitest.integration.config.ts
+              ;;
+            ci:rls)
+              bun run app:prepare
+              bun run db:migrate:deploy
+              bunx prisma db seed
+              PGPASSWORD=postgres psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+              CREATE ROLE life_ustc_runtime LOGIN PASSWORD 'runtime-test-password' NOINHERIT NOBYPASSRLS;
+              GRANT CONNECT ON DATABASE "${{ inputs.database-name }}" TO life_ustc_runtime;
+              GRANT USAGE ON SCHEMA public TO life_ustc_runtime;
+              GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO life_ustc_runtime;
+              GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO life_ustc_runtime;
+              SQL
+              runtime_database_url="postgresql://life_ustc_runtime:runtime-test-password@127.0.0.1:5432/${{ inputs.database-name }}"
+              DATABASE_URL="$runtime_database_url" bunx vitest run \
+                --config vitest.integration.config.ts \
+                tests/integration/todo-rls.test.ts
               ;;
             ci:e2e:build-artifacts)
               bun run app:prepare

--- a/prisma/migrations/20260722163000_todo_owner_rls/migration.sql
+++ b/prisma/migrations/20260722163000_todo_owner_rls/migration.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "Todo" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Todo" FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY "Todo_owner_isolation" ON "Todo"
+  FOR ALL
+  USING ("userId" = current_setting('app.user_id', true))
+  WITH CHECK ("userId" = current_setting('app.user_id', true));

--- a/tests/integration/todo-rls.test.ts
+++ b/tests/integration/todo-rls.test.ts
@@ -32,12 +32,18 @@ describe.skipIf(process.env.RLS_TEST_ENABLED !== "true")(
 
     it("runs as a non-owner role without BYPASSRLS", async () => {
       const [role] = await prisma.$queryRaw<
-        { currentUser: string; owner: boolean; bypassRls: boolean }[]
+        {
+          currentUser: string;
+          owner: boolean;
+          bypassRls: boolean;
+          inheritsRoles: boolean;
+        }[]
       >(Prisma.sql`
       SELECT
         current_user AS "currentUser",
         (current_user = tableowner) AS owner,
-        rolbypassrls AS "bypassRls"
+        rolbypassrls AS "bypassRls",
+        rolinherit AS "inheritsRoles"
       FROM pg_tables
       JOIN pg_roles ON rolname = current_user
       WHERE schemaname = 'public' AND tablename = 'Todo'
@@ -46,11 +52,20 @@ describe.skipIf(process.env.RLS_TEST_ENABLED !== "true")(
         currentUser: "life_ustc_runtime",
         owner: false,
         bypassRls: false,
+        inheritsRoles: false,
       });
     });
 
     it("defaults to no rows when user context is missing", async () => {
       await expect(prisma.todo.findMany()).resolves.toEqual([]);
+      await expect(
+        prisma.todo.create({
+          data: {
+            title: "[rls-test] missing context",
+            userId: firstUserId,
+          },
+        }),
+      ).rejects.toThrow();
     });
 
     it("isolates concurrent users and rejects forged ownership", async () => {

--- a/tests/integration/todo-rls.test.ts
+++ b/tests/integration/todo-rls.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Prisma } from "@/generated/prisma/client";
+import { prisma, withUserDbContext } from "@/lib/db/prisma";
+
+describe("Todo PostgreSQL row security", () => {
+  let firstUserId = "";
+  let secondUserId = "";
+  const createdIds: string[] = [];
+
+  beforeAll(async () => {
+    const users = await prisma.user.findMany({
+      select: { id: true },
+      orderBy: { id: "asc" },
+      take: 2,
+    });
+    if (users.length < 2) throw new Error("Expected two seeded users");
+    firstUserId = users[0].id;
+    secondUserId = users[1].id;
+  });
+
+  afterAll(async () => {
+    for (const userId of [firstUserId, secondUserId]) {
+      if (!userId) continue;
+      await withUserDbContext(userId, () =>
+        prisma.todo.deleteMany({ where: { id: { in: createdIds } } }),
+      );
+    }
+    await prisma.$disconnect();
+  });
+
+  it("runs as a non-owner role without BYPASSRLS", async () => {
+    const [role] = await prisma.$queryRaw<
+      { currentUser: string; owner: boolean; bypassRls: boolean }[]
+    >(Prisma.sql`
+      SELECT
+        current_user AS "currentUser",
+        (current_user = tableowner) AS owner,
+        rolbypassrls AS "bypassRls"
+      FROM pg_tables
+      JOIN pg_roles ON rolname = current_user
+      WHERE schemaname = 'public' AND tablename = 'Todo'
+    `);
+    expect(role).toEqual({
+      currentUser: "life_ustc_runtime",
+      owner: false,
+      bypassRls: false,
+    });
+  });
+
+  it("defaults to no rows when user context is missing", async () => {
+    await expect(prisma.todo.findMany()).resolves.toEqual([]);
+  });
+
+  it("isolates concurrent users and rejects forged ownership", async () => {
+    const first = await withUserDbContext(firstUserId, () =>
+      prisma.todo.create({
+        data: { title: "[rls-test] first", userId: firstUserId },
+        select: { id: true },
+      }),
+    );
+    const second = await withUserDbContext(secondUserId, () =>
+      prisma.todo.create({
+        data: { title: "[rls-test] second", userId: secondUserId },
+        select: { id: true },
+      }),
+    );
+    createdIds.push(first.id, second.id);
+
+    const [firstRows, secondRows] = await Promise.all([
+      withUserDbContext(firstUserId, () =>
+        prisma.todo.findMany({ select: { id: true } }),
+      ),
+      withUserDbContext(secondUserId, () =>
+        prisma.todo.findMany({ select: { id: true } }),
+      ),
+    ]);
+    expect(firstRows).toContainEqual({ id: first.id });
+    expect(firstRows).not.toContainEqual({ id: second.id });
+    expect(secondRows).toContainEqual({ id: second.id });
+    expect(secondRows).not.toContainEqual({ id: first.id });
+
+    await expect(
+      withUserDbContext(secondUserId, () =>
+        prisma.todo.create({
+          data: { title: "[rls-test] forged", userId: firstUserId },
+        }),
+      ),
+    ).rejects.toThrow();
+
+    await expect(
+      prisma.todo.findMany({ where: { id: { in: createdIds } } }),
+    ).resolves.toEqual([]);
+  });
+});

--- a/tests/integration/todo-rls.test.ts
+++ b/tests/integration/todo-rls.test.ts
@@ -2,36 +2,38 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { Prisma } from "@/generated/prisma/client";
 import { prisma, withUserDbContext } from "@/lib/db/prisma";
 
-describe("Todo PostgreSQL row security", () => {
-  let firstUserId = "";
-  let secondUserId = "";
-  const createdIds: string[] = [];
+describe.skipIf(process.env.RLS_TEST_ENABLED !== "true")(
+  "Todo PostgreSQL row security",
+  () => {
+    let firstUserId = "";
+    let secondUserId = "";
+    const createdIds: string[] = [];
 
-  beforeAll(async () => {
-    const users = await prisma.user.findMany({
-      select: { id: true },
-      orderBy: { id: "asc" },
-      take: 2,
+    beforeAll(async () => {
+      const users = await prisma.user.findMany({
+        select: { id: true },
+        orderBy: { id: "asc" },
+        take: 2,
+      });
+      if (users.length < 2) throw new Error("Expected two seeded users");
+      firstUserId = users[0].id;
+      secondUserId = users[1].id;
     });
-    if (users.length < 2) throw new Error("Expected two seeded users");
-    firstUserId = users[0].id;
-    secondUserId = users[1].id;
-  });
 
-  afterAll(async () => {
-    for (const userId of [firstUserId, secondUserId]) {
-      if (!userId) continue;
-      await withUserDbContext(userId, () =>
-        prisma.todo.deleteMany({ where: { id: { in: createdIds } } }),
-      );
-    }
-    await prisma.$disconnect();
-  });
+    afterAll(async () => {
+      for (const userId of [firstUserId, secondUserId]) {
+        if (!userId) continue;
+        await withUserDbContext(userId, () =>
+          prisma.todo.deleteMany({ where: { id: { in: createdIds } } }),
+        );
+      }
+      await prisma.$disconnect();
+    });
 
-  it("runs as a non-owner role without BYPASSRLS", async () => {
-    const [role] = await prisma.$queryRaw<
-      { currentUser: string; owner: boolean; bypassRls: boolean }[]
-    >(Prisma.sql`
+    it("runs as a non-owner role without BYPASSRLS", async () => {
+      const [role] = await prisma.$queryRaw<
+        { currentUser: string; owner: boolean; bypassRls: boolean }[]
+      >(Prisma.sql`
       SELECT
         current_user AS "currentUser",
         (current_user = tableowner) AS owner,
@@ -40,55 +42,56 @@ describe("Todo PostgreSQL row security", () => {
       JOIN pg_roles ON rolname = current_user
       WHERE schemaname = 'public' AND tablename = 'Todo'
     `);
-    expect(role).toEqual({
-      currentUser: "life_ustc_runtime",
-      owner: false,
-      bypassRls: false,
+      expect(role).toEqual({
+        currentUser: "life_ustc_runtime",
+        owner: false,
+        bypassRls: false,
+      });
     });
-  });
 
-  it("defaults to no rows when user context is missing", async () => {
-    await expect(prisma.todo.findMany()).resolves.toEqual([]);
-  });
+    it("defaults to no rows when user context is missing", async () => {
+      await expect(prisma.todo.findMany()).resolves.toEqual([]);
+    });
 
-  it("isolates concurrent users and rejects forged ownership", async () => {
-    const first = await withUserDbContext(firstUserId, () =>
-      prisma.todo.create({
-        data: { title: "[rls-test] first", userId: firstUserId },
-        select: { id: true },
-      }),
-    );
-    const second = await withUserDbContext(secondUserId, () =>
-      prisma.todo.create({
-        data: { title: "[rls-test] second", userId: secondUserId },
-        select: { id: true },
-      }),
-    );
-    createdIds.push(first.id, second.id);
-
-    const [firstRows, secondRows] = await Promise.all([
-      withUserDbContext(firstUserId, () =>
-        prisma.todo.findMany({ select: { id: true } }),
-      ),
-      withUserDbContext(secondUserId, () =>
-        prisma.todo.findMany({ select: { id: true } }),
-      ),
-    ]);
-    expect(firstRows).toContainEqual({ id: first.id });
-    expect(firstRows).not.toContainEqual({ id: second.id });
-    expect(secondRows).toContainEqual({ id: second.id });
-    expect(secondRows).not.toContainEqual({ id: first.id });
-
-    await expect(
-      withUserDbContext(secondUserId, () =>
+    it("isolates concurrent users and rejects forged ownership", async () => {
+      const first = await withUserDbContext(firstUserId, () =>
         prisma.todo.create({
-          data: { title: "[rls-test] forged", userId: firstUserId },
+          data: { title: "[rls-test] first", userId: firstUserId },
+          select: { id: true },
         }),
-      ),
-    ).rejects.toThrow();
+      );
+      const second = await withUserDbContext(secondUserId, () =>
+        prisma.todo.create({
+          data: { title: "[rls-test] second", userId: secondUserId },
+          select: { id: true },
+        }),
+      );
+      createdIds.push(first.id, second.id);
 
-    await expect(
-      prisma.todo.findMany({ where: { id: { in: createdIds } } }),
-    ).resolves.toEqual([]);
-  });
-});
+      const [firstRows, secondRows] = await Promise.all([
+        withUserDbContext(firstUserId, () =>
+          prisma.todo.findMany({ select: { id: true } }),
+        ),
+        withUserDbContext(secondUserId, () =>
+          prisma.todo.findMany({ select: { id: true } }),
+        ),
+      ]);
+      expect(firstRows).toContainEqual({ id: first.id });
+      expect(firstRows).not.toContainEqual({ id: second.id });
+      expect(secondRows).toContainEqual({ id: second.id });
+      expect(secondRows).not.toContainEqual({ id: first.id });
+
+      await expect(
+        withUserDbContext(secondUserId, () =>
+          prisma.todo.create({
+            data: { title: "[rls-test] forged", userId: firstUserId },
+          }),
+        ),
+      ).rejects.toThrow();
+
+      await expect(
+        prisma.todo.findMany({ where: { id: { in: createdIds } } }),
+      ).resolves.toEqual([]);
+    });
+  },
+);


### PR DESCRIPTION
Part of #550

## Summary
- activate and force PostgreSQL RLS on `Todo` with matching `USING` and `WITH CHECK` owner policy
- add a dedicated CI phase that creates a non-owner `NOINHERIT NOBYPASSRLS` runtime role and grants only runtime table access
- prove default-deny without context, concurrent A/B isolation, forged-owner rejection, context reset, and role attributes against a real PostgreSQL database

## Deployment order
This follows the already-merged inactive context plumbing in #596. It deliberately remains separate so the application context is deployed before policy activation. It does not close #550; the remaining table families need their own policy matrices.

## Verification
- fresh PostgreSQL migration replay + seed + runtime-role integration test: 3/3 passed locally
- `bunx vitest run tests/unit/rls-context.test.ts tests/unit/todo-service-delete.test.ts`: 8/8
- full unit suite on the activation commit: 235 files / 1439 tests (previous local run)

<!-- project-relationship:start -->
## Project relationship

Part of #601.
<!-- project-relationship:end -->