### PR TITLE
refactor(db): route personal preferences through RLS context

### DIFF
--- a/src/features/bus/server/bus-preferences.ts
+++ b/src/features/bus/server/bus-preferences.ts
@@ -1,4 +1,4 @@
-import { prisma } from "@/lib/db/prisma";
+import { prisma, withUserDbContext } from "@/lib/db/prisma";
 import type {
   BusPreferencePayload,
   BusUserPreferenceSummary,
@@ -12,10 +12,12 @@ export async function getBusPreference(
   userId: string | null,
 ): Promise<BusUserPreferenceSummary | null> {
   if (!userId) return null;
+  userId = userId.trim();
+  if (!userId) return null;
 
-  const preference = await prisma.busUserPreference.findUnique({
-    where: { userId },
-  });
+  const preference = await withUserDbContext(userId, () =>
+    prisma.busUserPreference.findUnique({ where: { userId } }),
+  );
 
   if (!preference) {
     return {
@@ -36,6 +38,8 @@ export async function saveBusPreference(
   userId: string,
   payload: BusPreferencePayload,
 ): Promise<SaveBusPreferenceResult> {
+  userId = userId.trim();
+  if (!userId) throw new Error("Bus preference user ID is required");
   const validationError = await validatePreferredBusCampuses(payload);
   if (validationError) {
     return { ok: false, error: validationError };
@@ -49,11 +53,13 @@ export async function saveBusPreference(
     showDepartedTrips: payload.showDepartedTrips,
   };
 
-  await prisma.busUserPreference.upsert({
-    where: { userId },
-    create: { userId, ...data },
-    update: data,
-  });
+  await withUserDbContext(userId, () =>
+    prisma.busUserPreference.upsert({
+      where: { userId },
+      create: { userId, ...data },
+      update: data,
+    }),
+  );
 
   return {
     ok: true,

--- a/src/features/dashboard-links/server/dashboard-link-data.ts
+++ b/src/features/dashboard-links/server/dashboard-link-data.ts
@@ -1,6 +1,6 @@
 import { DASHBOARD_LINK_GROUPS } from "@/features/dashboard-links/lib/dashboard-links";
 import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
-import { prisma } from "@/lib/db/prisma";
+import { prisma, withUserDbContext } from "@/lib/db/prisma";
 import {
   buildDashboardLinkSummaries,
   dashboardLinksForSlugs,
@@ -43,47 +43,49 @@ export async function getSignedInDashboardLinksData(
   userId: string,
   locale: AppLocale = DEFAULT_LOCALE,
 ): Promise<DashboardLinksData> {
-  const [clickRows, pinRows] = await Promise.all([
-    prisma.dashboardLinkClick.findMany({
-      where: { userId },
+  const normalizedUserId = userId.trim();
+  if (!normalizedUserId) throw new Error("Dashboard link user ID is required");
+  return withUserDbContext(normalizedUserId, async () => {
+    const clickRows = await prisma.dashboardLinkClick.findMany({
+      where: { userId: normalizedUserId },
       select: { slug: true, count: true },
-    }),
-    prisma.dashboardLinkPin.findMany({
-      where: { userId },
+    });
+    const pinRows = await prisma.dashboardLinkPin.findMany({
+      where: { userId: normalizedUserId },
       select: { slug: true },
       orderBy: { createdAt: "asc" },
-    }),
-  ]);
-  const clickStats: Record<string, number> = Object.fromEntries(
-    clickRows.map((row) => [row.slug, row.count]),
-  );
-  const pinnedSlugSet = new Set(pinRows.map((row) => row.slug));
+    });
+    const clickStats: Record<string, number> = Object.fromEntries(
+      clickRows.map((row) => [row.slug, row.count]),
+    );
+    const pinnedSlugSet = new Set(pinRows.map((row) => row.slug));
 
-  const { dashboardLinks, dashboardLinkBySlug } = buildDashboardLinkSummaries(
-    clickStats,
-    pinnedSlugSet,
-    locale,
-  );
-  const pinnedLinks = dashboardLinksForSlugs(
-    pinRows.map((row) => row.slug),
-    dashboardLinkBySlug,
-  );
-  const recommendedLinks = recommendedDashboardLinkSummaries(
-    clickStats,
-    pinnedSlugSet,
-    locale,
-  );
-  const overviewLinks = [...pinnedLinks, ...recommendedLinks].slice(
-    0,
-    MAX_OVERVIEW_LINKS,
-  );
+    const { dashboardLinks, dashboardLinkBySlug } = buildDashboardLinkSummaries(
+      clickStats,
+      pinnedSlugSet,
+      locale,
+    );
+    const pinnedLinks = dashboardLinksForSlugs(
+      pinRows.map((row) => row.slug),
+      dashboardLinkBySlug,
+    );
+    const recommendedLinks = recommendedDashboardLinkSummaries(
+      clickStats,
+      pinnedSlugSet,
+      locale,
+    );
+    const overviewLinks = [...pinnedLinks, ...recommendedLinks].slice(
+      0,
+      MAX_OVERVIEW_LINKS,
+    );
 
-  return {
-    dashboardLinks,
-    recommendedLinks,
-    pinnedLinks,
-    overviewLinks,
-  };
+    return {
+      dashboardLinks,
+      recommendedLinks,
+      pinnedLinks,
+      overviewLinks,
+    };
+  });
 }
 
 export async function getLinksTabData(

--- a/src/features/dashboard-links/server/dashboard-link-service.ts
+++ b/src/features/dashboard-links/server/dashboard-link-service.ts
@@ -1,5 +1,5 @@
 import { USTC_DASHBOARD_LINKS } from "@/features/dashboard-links/lib/dashboard-links";
-import { prisma } from "@/lib/db/prisma";
+import { prisma, withUserDbContext } from "@/lib/db/prisma";
 import { logAppEvent } from "@/lib/log/app-logger";
 
 export const MAX_PINNED_LINKS = 4;
@@ -26,11 +26,11 @@ type DashboardLinkPinPrisma = {
   dashboardLinkPin: DashboardLinkPinDelegate;
 };
 
-type DashboardLinkPinTransactionPrisma = DashboardLinkPinPrisma & {
-  $transaction: <Result>(
-    callback: (tx: DashboardLinkPinPrisma) => Promise<Result>,
-  ) => Promise<Result>;
-};
+function normalizeUserId(userId: string) {
+  const normalized = userId.trim();
+  if (!normalized) throw new Error("Dashboard link user ID is required");
+  return normalized;
+}
 
 export function resolveDashboardLinkBySlug(slug: string | null | undefined) {
   const normalizedSlug = slug?.trim();
@@ -48,25 +48,28 @@ export function sanitizeDashboardReturnTo(value: string | undefined): string {
 }
 
 export async function recordDashboardLinkClick(userId: string, slug: string) {
+  userId = normalizeUserId(userId);
   try {
-    await prisma.dashboardLinkClick.upsert({
-      where: {
-        userId_slug: {
+    await withUserDbContext(userId, () =>
+      prisma.dashboardLinkClick.upsert({
+        where: {
+          userId_slug: {
+            userId,
+            slug,
+          },
+        },
+        create: {
           userId,
           slug,
+          count: 1,
+          lastClickedAt: new Date(),
         },
-      },
-      create: {
-        userId,
-        slug,
-        count: 1,
-        lastClickedAt: new Date(),
-      },
-      update: {
-        count: { increment: 1 },
-        lastClickedAt: new Date(),
-      },
-    });
+        update: {
+          count: { increment: 1 },
+          lastClickedAt: new Date(),
+        },
+      }),
+    );
   } catch (error) {
     logAppEvent(
       "warn",
@@ -90,11 +93,14 @@ export async function updateDashboardLinkPinState({
   slug: string;
   userId: string;
 }) {
-  if (action === "pin") {
-    return pinDashboardLink(prisma, userId, slug);
-  }
+  userId = normalizeUserId(userId);
+  return withUserDbContext(userId, () => {
+    if (action === "pin") {
+      return pinDashboardLink(prisma, userId, slug);
+    }
 
-  return unpinDashboardLink(prisma, userId, slug);
+    return unpinDashboardLink(prisma, userId, slug);
+  });
 }
 
 export function logDashboardLinkPinFailure({
@@ -122,35 +128,33 @@ export function logDashboardLinkPinFailure({
 }
 
 async function pinDashboardLink(
-  prisma: DashboardLinkPinTransactionPrisma,
+  prisma: DashboardLinkPinPrisma,
   userId: string,
   slug: string,
 ) {
-  return prisma.$transaction(async (tx) => {
-    await tx.dashboardLinkPin.upsert({
-      where: { userId_slug: { userId, slug } },
-      create: { userId, slug },
-      update: {},
-    });
-
-    const pinnedRows = await tx.dashboardLinkPin.findMany({
-      where: { userId },
-      select: { slug: true },
-      orderBy: { createdAt: "asc" },
-    });
-    const overflowRows = pinnedRows.slice(0, -MAX_PINNED_LINKS);
-
-    if (overflowRows.length > 0) {
-      await tx.dashboardLinkPin.deleteMany({
-        where: {
-          userId,
-          slug: { in: overflowRows.map((row) => row.slug) },
-        },
-      });
-    }
-
-    return listDashboardLinkPins(tx, userId);
+  await prisma.dashboardLinkPin.upsert({
+    where: { userId_slug: { userId, slug } },
+    create: { userId, slug },
+    update: {},
   });
+
+  const pinnedRows = await prisma.dashboardLinkPin.findMany({
+    where: { userId },
+    select: { slug: true },
+    orderBy: { createdAt: "asc" },
+  });
+  const overflowRows = pinnedRows.slice(0, -MAX_PINNED_LINKS);
+
+  if (overflowRows.length > 0) {
+    await prisma.dashboardLinkPin.deleteMany({
+      where: {
+        userId,
+        slug: { in: overflowRows.map((row) => row.slug) },
+      },
+    });
+  }
+
+  return listDashboardLinkPins(prisma, userId);
 }
 
 async function unpinDashboardLink(

--- a/tests/unit/bus-preferences-route.test.ts
+++ b/tests/unit/bus-preferences-route.test.ts
@@ -23,6 +23,10 @@ vi.mock("@/lib/auth/api-auth", () => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   prisma: prismaMock,
+  withUserDbContext: vi.fn(
+    async (_userId: string, action: (tx: unknown) => Promise<unknown>) =>
+      action({}),
+  ),
 }));
 
 function preferenceRequest(body: unknown) {

--- a/tests/unit/dashboard-link-pin-route.test.ts
+++ b/tests/unit/dashboard-link-pin-route.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const requireAuthMock = vi.fn();
-const transactionMock = vi.fn();
+const withUserDbContextMock = vi.fn();
 
 vi.mock("@/lib/auth/api-auth", () => ({
   requireAuth: requireAuthMock,
@@ -9,19 +9,19 @@ vi.mock("@/lib/auth/api-auth", () => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   prisma: {
-    $transaction: transactionMock,
     dashboardLinkPin: {
       deleteMany: vi.fn(),
       findMany: vi.fn(),
     },
   },
+  withUserDbContext: withUserDbContextMock,
 }));
 
 describe("POST /api/dashboard-links/pin", () => {
   beforeEach(() => {
     vi.resetModules();
     requireAuthMock.mockResolvedValue({ userId: "user-1" });
-    transactionMock.mockReset();
+    withUserDbContextMock.mockReset();
   });
 
   afterEach(() => {
@@ -29,7 +29,7 @@ describe("POST /api/dashboard-links/pin", () => {
   });
 
   it("当固定链接持久化失败时返回 500 JSON 错误", async () => {
-    transactionMock.mockRejectedValue(new Error("db write failed"));
+    withUserDbContextMock.mockRejectedValue(new Error("db write failed"));
     const { postDashboardLinkPinRoute } = await import(
       "@/lib/api/routes/dashboard-link-pin-route"
     );
@@ -78,7 +78,7 @@ describe("POST /api/dashboard-links/pin", () => {
 
     expect(response.status).toBe(429);
     expect(response.headers.get("Retry-After")).toBe("60");
-    expect(transactionMock).not.toHaveBeenCalled();
+    expect(withUserDbContextMock).not.toHaveBeenCalled();
   });
 
   it("HTML 表单被限流时重定向并标记错误", async () => {
@@ -103,6 +103,6 @@ describe("POST /api/dashboard-links/pin", () => {
     expect(response.headers.get("Location")).toBe(
       "http://localhost/?dashboardLinkPinError=1",
     );
-    expect(transactionMock).not.toHaveBeenCalled();
+    expect(withUserDbContextMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/personal-data-rls-context.test.ts
+++ b/tests/unit/personal-data-rls-context.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  busFindUniqueMock,
+  clickFindManyMock,
+  clickUpsertMock,
+  pinDeleteManyMock,
+  pinFindManyMock,
+  pinUpsertMock,
+  withUserDbContextMock,
+} = vi.hoisted(() => ({
+  busFindUniqueMock: vi.fn(),
+  clickFindManyMock: vi.fn(),
+  clickUpsertMock: vi.fn(),
+  pinDeleteManyMock: vi.fn(),
+  pinFindManyMock: vi.fn(),
+  pinUpsertMock: vi.fn(),
+  withUserDbContextMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    busUserPreference: { findUnique: busFindUniqueMock },
+    dashboardLinkClick: {
+      findMany: clickFindManyMock,
+      upsert: clickUpsertMock,
+    },
+    dashboardLinkPin: {
+      deleteMany: pinDeleteManyMock,
+      findMany: pinFindManyMock,
+      upsert: pinUpsertMock,
+    },
+  },
+  withUserDbContext: withUserDbContextMock,
+}));
+
+import { getBusPreference } from "@/features/bus/server/bus-preferences";
+import { getSignedInDashboardLinksData } from "@/features/dashboard-links/server/dashboard-link-data";
+import {
+  recordDashboardLinkClick,
+  updateDashboardLinkPinState,
+} from "@/features/dashboard-links/server/dashboard-link-service";
+
+describe("personal data RLS contexts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    withUserDbContextMock.mockImplementation(
+      async (_userId: string, action: (tx: unknown) => Promise<unknown>) =>
+        action({}),
+    );
+  });
+
+  it("uses one normalized context for a dashboard pin transaction", async () => {
+    pinUpsertMock.mockResolvedValue({});
+    pinFindManyMock
+      .mockResolvedValueOnce([{ slug: "mail" }])
+      .mockResolvedValueOnce([{ slug: "mail" }]);
+
+    await expect(
+      updateDashboardLinkPinState({
+        action: "pin",
+        slug: "mail",
+        userId: " user-1 ",
+      }),
+    ).resolves.toEqual(["mail"]);
+
+    expect(withUserDbContextMock).toHaveBeenCalledWith(
+      "user-1",
+      expect.any(Function),
+    );
+    expect(pinUpsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: { slug: "mail", userId: "user-1" },
+      }),
+    );
+  });
+
+  it("serializes dashboard reads inside one user transaction", async () => {
+    clickFindManyMock.mockResolvedValue([]);
+    pinFindManyMock.mockResolvedValue([]);
+
+    await getSignedInDashboardLinksData("user-1");
+
+    expect(withUserDbContextMock).toHaveBeenCalledOnce();
+    expect(clickFindManyMock.mock.invocationCallOrder[0]).toBeLessThan(
+      pinFindManyMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("routes click and bus preference reads through their owner context", async () => {
+    clickUpsertMock.mockResolvedValue({});
+    busFindUniqueMock.mockResolvedValue(null);
+
+    await recordDashboardLinkClick("user-1", "mail");
+    await getBusPreference("user-1");
+
+    expect(withUserDbContextMock).toHaveBeenNthCalledWith(
+      1,
+      "user-1",
+      expect.any(Function),
+    );
+    expect(withUserDbContextMock).toHaveBeenNthCalledWith(
+      2,
+      "user-1",
+      expect.any(Function),
+    );
+  });
+});


### PR DESCRIPTION
Part of #550

## Summary
- route dashboard click, dashboard pin, and bus-preference reads/writes through the same short transaction-local user context introduced by #596
- replace the dashboard pin nested transaction with the outer RLS transaction and serialize dependent reads on one connection
- normalize the owner ID once for both transaction identity and row filters/writes
- add focused context/ordering tests and update route mocks to match the production transaction callback

No policy is activated here. Activation remains a later migration after this plumbing is deployed. `Upload` and `HomeworkCompletion` are intentionally excluded from this owner-only slice because public attachment/profile-contribution reads require distinct SELECT policies.

## Verification
- focused dashboard/bus tests: 19 passed
- new personal-data context tests: 3 passed
- `svelte-check`: 0 errors / 0 warnings

<!-- project-relationship:start -->
## Project relationship

Part of #601.
<!-- project-relationship:end -->