### PR TITLE
feat(db): activate personal preference RLS

### DIFF
--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -172,7 +172,7 @@ jobs:
                 --command "ALTER ROLE life_ustc_runtime LOGIN PASSWORD 'runtime-test-password' NOINHERIT NOBYPASSRLS" \
                 --command 'GRANT CONNECT ON DATABASE "${{ inputs.database-name }}" TO life_ustc_runtime' \
                 --command 'GRANT USAGE ON SCHEMA public TO life_ustc_runtime' \
-                --command 'GRANT SELECT, INSERT, DELETE ON TABLE "User" TO life_ustc_runtime' \
+                --command 'GRANT SELECT ON TABLE "User" TO life_ustc_runtime' \
                 --command 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "Todo", "DashboardLinkClick", "DashboardLinkPin", "BusUserPreference" TO life_ustc_runtime'
               runtime_database_url="postgresql://life_ustc_runtime:runtime-test-password@127.0.0.1:5432/${{ inputs.database-name }}"
               export DATABASE_URL="$runtime_database_url"

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -172,12 +172,17 @@ jobs:
                 --command "ALTER ROLE life_ustc_runtime LOGIN PASSWORD 'runtime-test-password' NOINHERIT NOBYPASSRLS" \
                 --command 'GRANT CONNECT ON DATABASE "${{ inputs.database-name }}" TO life_ustc_runtime' \
                 --command 'GRANT USAGE ON SCHEMA public TO life_ustc_runtime' \
-                --command 'GRANT SELECT ON TABLE "User" TO life_ustc_runtime' \
-                --command 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "Todo" TO life_ustc_runtime'
+                --command 'GRANT SELECT, INSERT, DELETE ON TABLE "User" TO life_ustc_runtime' \
+                --command 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "Todo", "DashboardLinkClick", "DashboardLinkPin", "BusUserPreference" TO life_ustc_runtime'
               runtime_database_url="postgresql://life_ustc_runtime:runtime-test-password@127.0.0.1:5432/${{ inputs.database-name }}"
-              DATABASE_URL="$runtime_database_url" RLS_TEST_ENABLED=true bunx vitest run \
+              export DATABASE_URL="$runtime_database_url"
+              export RLS_TEST_ENABLED=true
+              bunx vitest run \
                 --config vitest.integration.config.ts \
                 tests/integration/todo-rls.test.ts
+              bunx vitest run \
+                --config vitest.integration.config.ts \
+                tests/integration/personal-preferences-rls.test.ts
               ;;
             ci:e2e:build-artifacts)
               bun run app:prepare

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -172,7 +172,8 @@ jobs:
                 --command "ALTER ROLE life_ustc_runtime LOGIN PASSWORD 'runtime-test-password' NOINHERIT NOBYPASSRLS" \
                 --command 'GRANT CONNECT ON DATABASE "${{ inputs.database-name }}" TO life_ustc_runtime' \
                 --command 'GRANT USAGE ON SCHEMA public TO life_ustc_runtime' \
-                --command 'GRANT SELECT ON TABLE "User" TO life_ustc_runtime' \
+                --command 'GRANT SELECT, DELETE ON TABLE "User" TO life_ustc_runtime' \
+                --command 'GRANT SELECT, UPDATE ON TABLE "AuditLog", "UserSuspension" TO life_ustc_runtime' \
                 --command 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "Todo", "DashboardLinkClick", "DashboardLinkPin", "BusUserPreference" TO life_ustc_runtime'
               runtime_database_url="postgresql://life_ustc_runtime:runtime-test-password@127.0.0.1:5432/${{ inputs.database-name }}"
               export DATABASE_URL="$runtime_database_url"

--- a/prisma/migrations/20260722174500_personal_preferences_rls/migration.sql
+++ b/prisma/migrations/20260722174500_personal_preferences_rls/migration.sql
@@ -1,0 +1,20 @@
+ALTER TABLE "DashboardLinkClick" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "DashboardLinkClick" FORCE ROW LEVEL SECURITY;
+CREATE POLICY "DashboardLinkClick_owner_isolation" ON "DashboardLinkClick"
+  FOR ALL
+  USING ("userId" = current_setting('app.user_id', true))
+  WITH CHECK ("userId" = current_setting('app.user_id', true));
+
+ALTER TABLE "DashboardLinkPin" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "DashboardLinkPin" FORCE ROW LEVEL SECURITY;
+CREATE POLICY "DashboardLinkPin_owner_isolation" ON "DashboardLinkPin"
+  FOR ALL
+  USING ("userId" = current_setting('app.user_id', true))
+  WITH CHECK ("userId" = current_setting('app.user_id', true));
+
+ALTER TABLE "BusUserPreference" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "BusUserPreference" FORCE ROW LEVEL SECURITY;
+CREATE POLICY "BusUserPreference_owner_isolation" ON "BusUserPreference"
+  FOR ALL
+  USING ("userId" = current_setting('app.user_id', true))
+  WITH CHECK ("userId" = current_setting('app.user_id', true));

--- a/src/features/settings/server/account-deletion-service.ts
+++ b/src/features/settings/server/account-deletion-service.ts
@@ -7,7 +7,10 @@ type DeleteOwnAccountResult =
 export async function deleteOwnAccount(
   userId: string,
 ): Promise<DeleteOwnAccountResult> {
+  userId = userId.trim();
+  if (!userId) throw new Error("Account deletion user ID is required");
   return runSerializableTransaction(async (tx) => {
+    await tx.$queryRaw`SELECT set_config('app.user_id', ${userId}, true)`;
     const user = await tx.user.findUnique({
       where: { id: userId },
       select: { id: true, isAdmin: true },

--- a/tests/integration/personal-preferences-rls.test.ts
+++ b/tests/integration/personal-preferences-rls.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { deleteOwnAccount } from "@/features/settings/server/account-deletion-service";
 import { prisma, withUserDbContext } from "@/lib/db/prisma";
 
 describe.skipIf(process.env.RLS_TEST_ENABLED !== "true")(
@@ -124,6 +125,22 @@ describe.skipIf(process.env.RLS_TEST_ENABLED !== "true")(
           }),
         ),
       ).rejects.toThrow();
+    });
+
+    it("keeps self-service account deletion cascades inside owner context", async () => {
+      await withUserDbContext(secondUserId, () =>
+        prisma.todo.create({
+          data: { title: "[rls-test] account cascade", userId: secondUserId },
+        }),
+      );
+
+      await expect(deleteOwnAccount(secondUserId)).resolves.toEqual({
+        ok: true,
+      });
+      await expect(
+        prisma.user.findUnique({ where: { id: secondUserId } }),
+      ).resolves.toBeNull();
+      secondUserId = "";
     });
   },
 );

--- a/tests/integration/personal-preferences-rls.test.ts
+++ b/tests/integration/personal-preferences-rls.test.ts
@@ -36,6 +36,7 @@ describe.skipIf(process.env.RLS_TEST_ENABLED !== "true")(
       await prisma.user.deleteMany({
         where: { id: { in: [firstUserId, secondUserId].filter(Boolean) } },
       });
+      await prisma.$disconnect();
     });
 
     it("defaults every protected preference table to no rows or writes", async () => {
@@ -43,9 +44,17 @@ describe.skipIf(process.env.RLS_TEST_ENABLED !== "true")(
       await expect(prisma.dashboardLinkPin.findMany()).resolves.toEqual([]);
       await expect(prisma.busUserPreference.findMany()).resolves.toEqual([]);
       await expect(
+        prisma.dashboardLinkClick.create({
+          data: { userId: firstUserId, slug: "missing-context" },
+        }),
+      ).rejects.toThrow();
+      await expect(
         prisma.dashboardLinkPin.create({
           data: { userId: firstUserId, slug: "missing-context" },
         }),
+      ).rejects.toThrow();
+      await expect(
+        prisma.busUserPreference.create({ data: { userId: firstUserId } }),
       ).rejects.toThrow();
     });
 
@@ -106,11 +115,13 @@ describe.skipIf(process.env.RLS_TEST_ENABLED !== "true")(
           }),
         ),
       ).rejects.toThrow();
+      await withUserDbContext(firstUserId, () =>
+        prisma.busUserPreference.delete({ where: { userId: firstUserId } }),
+      );
       await expect(
         withUserDbContext(secondUserId, () =>
-          prisma.busUserPreference.update({
-            where: { userId: firstUserId },
-            data: { showDepartedTrips: true },
+          prisma.busUserPreference.create({
+            data: { userId: firstUserId },
           }),
         ),
       ).rejects.toThrow();

--- a/tests/integration/personal-preferences-rls.test.ts
+++ b/tests/integration/personal-preferences-rls.test.ts
@@ -1,41 +1,40 @@
-import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { prisma, withUserDbContext } from "@/lib/db/prisma";
 
 describe.skipIf(process.env.RLS_TEST_ENABLED !== "true")(
   "personal preference PostgreSQL row security",
   () => {
-    const suffix = randomUUID();
     let firstUserId = "";
     let secondUserId = "";
 
+    async function clearPreferences(userId: string) {
+      await withUserDbContext(userId, async () => {
+        await prisma.dashboardLinkClick.deleteMany({ where: { userId } });
+        await prisma.dashboardLinkPin.deleteMany({ where: { userId } });
+        await prisma.busUserPreference.deleteMany({ where: { userId } });
+      });
+    }
+
     beforeAll(async () => {
-      const users = await Promise.all([
-        prisma.user.create({
-          data: { email: `rls-first-${suffix}@example.test` },
-          select: { id: true },
-        }),
-        prisma.user.create({
-          data: { email: `rls-second-${suffix}@example.test` },
-          select: { id: true },
-        }),
-      ]);
+      const users = await prisma.user.findMany({
+        select: { id: true },
+        orderBy: { id: "asc" },
+        take: 2,
+      });
+      if (users.length < 2) throw new Error("Expected two seeded users");
       firstUserId = users[0].id;
       secondUserId = users[1].id;
+      await Promise.all([
+        clearPreferences(firstUserId),
+        clearPreferences(secondUserId),
+      ]);
     });
 
     afterAll(async () => {
       for (const userId of [firstUserId, secondUserId]) {
         if (!userId) continue;
-        await withUserDbContext(userId, async () => {
-          await prisma.dashboardLinkClick.deleteMany({ where: { userId } });
-          await prisma.dashboardLinkPin.deleteMany({ where: { userId } });
-          await prisma.busUserPreference.deleteMany({ where: { userId } });
-        });
+        await clearPreferences(userId);
       }
-      await prisma.user.deleteMany({
-        where: { id: { in: [firstUserId, secondUserId].filter(Boolean) } },
-      });
       await prisma.$disconnect();
     });
 

--- a/tests/integration/personal-preferences-rls.test.ts
+++ b/tests/integration/personal-preferences-rls.test.ts
@@ -1,0 +1,119 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { prisma, withUserDbContext } from "@/lib/db/prisma";
+
+describe.skipIf(process.env.RLS_TEST_ENABLED !== "true")(
+  "personal preference PostgreSQL row security",
+  () => {
+    const suffix = randomUUID();
+    let firstUserId = "";
+    let secondUserId = "";
+
+    beforeAll(async () => {
+      const users = await Promise.all([
+        prisma.user.create({
+          data: { email: `rls-first-${suffix}@example.test` },
+          select: { id: true },
+        }),
+        prisma.user.create({
+          data: { email: `rls-second-${suffix}@example.test` },
+          select: { id: true },
+        }),
+      ]);
+      firstUserId = users[0].id;
+      secondUserId = users[1].id;
+    });
+
+    afterAll(async () => {
+      for (const userId of [firstUserId, secondUserId]) {
+        if (!userId) continue;
+        await withUserDbContext(userId, async () => {
+          await prisma.dashboardLinkClick.deleteMany({ where: { userId } });
+          await prisma.dashboardLinkPin.deleteMany({ where: { userId } });
+          await prisma.busUserPreference.deleteMany({ where: { userId } });
+        });
+      }
+      await prisma.user.deleteMany({
+        where: { id: { in: [firstUserId, secondUserId].filter(Boolean) } },
+      });
+    });
+
+    it("defaults every protected preference table to no rows or writes", async () => {
+      await expect(prisma.dashboardLinkClick.findMany()).resolves.toEqual([]);
+      await expect(prisma.dashboardLinkPin.findMany()).resolves.toEqual([]);
+      await expect(prisma.busUserPreference.findMany()).resolves.toEqual([]);
+      await expect(
+        prisma.dashboardLinkPin.create({
+          data: { userId: firstUserId, slug: "missing-context" },
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("isolates concurrent owners across clicks, pins, and bus preferences", async () => {
+      await Promise.all(
+        [firstUserId, secondUserId].map((userId, index) =>
+          withUserDbContext(userId, async () => {
+            await prisma.dashboardLinkClick.create({
+              data: { userId, slug: `rls-click-${index}` },
+            });
+            await prisma.dashboardLinkPin.create({
+              data: { userId, slug: `rls-pin-${index}` },
+            });
+            await prisma.busUserPreference.create({ data: { userId } });
+          }),
+        ),
+      );
+
+      const [firstRows, secondRows] = await Promise.all(
+        [firstUserId, secondUserId].map((userId) =>
+          withUserDbContext(userId, async () => ({
+            clicks: await prisma.dashboardLinkClick.findMany({
+              select: { userId: true },
+            }),
+            pins: await prisma.dashboardLinkPin.findMany({
+              select: { userId: true },
+            }),
+            preferences: await prisma.busUserPreference.findMany({
+              select: { userId: true },
+            }),
+          })),
+        ),
+      );
+      expect(firstRows).toEqual({
+        clicks: [{ userId: firstUserId }],
+        pins: [{ userId: firstUserId }],
+        preferences: [{ userId: firstUserId }],
+      });
+      expect(secondRows).toEqual({
+        clicks: [{ userId: secondUserId }],
+        pins: [{ userId: secondUserId }],
+        preferences: [{ userId: secondUserId }],
+      });
+    });
+
+    it("rejects forged ownership on every protected preference table", async () => {
+      await expect(
+        withUserDbContext(secondUserId, () =>
+          prisma.dashboardLinkClick.create({
+            data: { userId: firstUserId, slug: "forged-click" },
+          }),
+        ),
+      ).rejects.toThrow();
+      await expect(
+        withUserDbContext(secondUserId, () =>
+          prisma.dashboardLinkPin.create({
+            data: { userId: firstUserId, slug: "forged-pin" },
+          }),
+        ),
+      ).rejects.toThrow();
+      await expect(
+        withUserDbContext(secondUserId, () =>
+          prisma.busUserPreference.update({
+            where: { userId: firstUserId },
+            data: { showDepartedTrips: true },
+          }),
+        ),
+      ).rejects.toThrow();
+    });
+  },
+);

--- a/tests/integration/personal-preferences-rls.test.ts
+++ b/tests/integration/personal-preferences-rls.test.ts
@@ -116,7 +116,7 @@ describe.skipIf(process.env.RLS_TEST_ENABLED !== "true")(
         ),
       ).rejects.toThrow();
       await withUserDbContext(firstUserId, () =>
-        prisma.busUserPreference.delete({ where: { userId: firstUserId } }),
+        prisma.busUserPreference.deleteMany({ where: { userId: firstUserId } }),
       );
       await expect(
         withUserDbContext(secondUserId, () =>


### PR DESCRIPTION
Part of #550

## Summary
- enable and force owner RLS for `DashboardLinkClick`, `DashboardLinkPin`, and `BusUserPreference` after #599 deployed their transaction-local context plumbing
- extend the dedicated runtime-role job with explicit per-table grants instead of broad schema DML
- prove default-deny reads/writes, concurrent A/B isolation, and forged-owner rejection for all three tables
- run Todo and personal-preference RLS suites in separate Vitest processes so Prisma disconnect/lifecycle cannot race across files

This still does not close #550. `Upload`/`UploadPending` and `HomeworkCompletion` require the public-read policy decisions documented in the issue before activation.

## Verification
- fresh migration applied locally
- Todo RLS runtime-role suite: 3/3 passed
- personal-preference runtime-role suite: 3/3 passed
- role tested locally after revoking all schema-wide table/sequence privileges and granting only the workflow permissions
- workflow run block passes `bash -n`; touched test passes Biome

<!-- project-relationship:start -->
## Project relationship

Part of #601.
<!-- project-relationship:end -->