### PR TITLE
fix(observability): isolate cache analytics namespaces

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -60,6 +60,9 @@ high-cardinality resource IDs.
   `page_request_v2`, `mcp_transport_v2`, `oauth_event_v2`, `audit_write_v2`,
   `storage_operation_v2`, `public_runtime_cache_v2`, and
   `graphql_operation_v2`) preserve this explicit meaning.
+- Public runtime cache datapoints use explicit, low-cardinality resource
+  namespaces. Full cache keys, including search and filter values, never enter
+  the Analytics Engine writer.
 
 ## Endpoints
 

--- a/src/features/catalog/server/public-course-list-data.ts
+++ b/src/features/catalog/server/public-course-list-data.ts
@@ -25,6 +25,7 @@ export async function getCourseListPage(
     url.searchParams,
   );
   return cachedPublicRuntimeData(
+    `page:course-list:${locale}`,
     publicRuntimeCacheKey(`page:course-list:${locale}`, searchParams),
     COURSE_LIST_CACHE_TTL_MS,
     () => getUncachedCourseListPage(searchParams, locale),

--- a/src/features/catalog/server/public-section-list-data.ts
+++ b/src/features/catalog/server/public-section-list-data.ts
@@ -25,6 +25,7 @@ export async function getSectionListPage(
     url.searchParams,
   );
   return cachedPublicRuntimeData(
+    `page:section-list:${locale}`,
     publicRuntimeCacheKey(`page:section-list:${locale}`, searchParams),
     SECTION_LIST_CACHE_TTL_MS,
     () => getUncachedSectionListPage(searchParams, locale),

--- a/src/features/catalog/server/public-teacher-list-data.ts
+++ b/src/features/catalog/server/public-teacher-list-data.ts
@@ -2,6 +2,7 @@ import { normalizeCatalogListQuery } from "@/features/catalog/lib/catalog-list-q
 import { paginatedTeacherQuery } from "@/features/catalog/server/academic-paginated-queries";
 import { CATALOG_PAGE_SIZE } from "@/features/catalog/server/catalog-page-constants";
 import { buildTeacherWhere } from "@/features/catalog/server/teacher-query";
+import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
 import { getMessages } from "@/i18n/messages.server";
 import { getPrisma } from "@/lib/db/prisma";
 import {
@@ -16,12 +17,16 @@ import {
 
 const TEACHER_LIST_CACHE_TTL_MS = 60_000;
 
-export async function getTeacherListPage(url: URL, locale = "zh-cn") {
+export async function getTeacherListPage(
+  url: URL,
+  locale: AppLocale = DEFAULT_LOCALE,
+) {
   const searchParams = normalizeCatalogListQuery(
     "/catalog/teachers",
     url.searchParams,
   );
   return cachedPublicRuntimeData(
+    `page:teacher-list:${locale}`,
     publicRuntimeCacheKey(`page:teacher-list:${locale}`, searchParams),
     TEACHER_LIST_CACHE_TTL_MS,
     () => getUncachedTeacherListPage(searchParams, locale),
@@ -30,7 +35,7 @@ export async function getTeacherListPage(url: URL, locale = "zh-cn") {
 
 async function getUncachedTeacherListPage(
   searchParams: URLSearchParams,
-  locale = "zh-cn",
+  locale: AppLocale = DEFAULT_LOCALE,
 ) {
   const page = parsePositivePage(searchParams.get("page"));
   const search = optionalValue(searchParams.get("search"));

--- a/src/lib/api/routes/academic-course-routes.ts
+++ b/src/lib/api/routes/academic-course-routes.ts
@@ -37,6 +37,7 @@ export async function getCoursesRoute(request: Request) {
 
   try {
     const result = await cachedPublicRuntimeData(
+      `api:courses:${locale}`,
       publicRuntimeCacheKey(`api:courses:${locale}`, searchParams),
       COURSES_API_CACHE_TTL_MS,
       async () => {

--- a/src/lib/api/routes/academic-metadata-routes.ts
+++ b/src/lib/api/routes/academic-metadata-routes.ts
@@ -20,6 +20,7 @@ export async function getMetadataRoute() {
   try {
     const metadata = await cachedPublicRuntimeData(
       "api:metadata",
+      "api:metadata",
       METADATA_API_CACHE_TTL_MS,
       getAcademicMetadata,
     );
@@ -47,6 +48,7 @@ export async function getSemestersRoute(request: Request) {
     const { page, pageSize } = parsed.pagination;
 
     const result = await cachedPublicRuntimeData(
+      "api:semesters",
       `api:semesters:${JSON.stringify({ page, pageSize })}`,
       SEMESTERS_API_CACHE_TTL_MS,
       () => listSemesters({ page, pageSize }),

--- a/src/lib/api/routes/academic-section-list-action.ts
+++ b/src/lib/api/routes/academic-section-list-action.ts
@@ -26,6 +26,7 @@ export async function listSectionsAction(
   cacheHeaders: HeadersInit,
 ) {
   const result = await cachedPublicRuntimeData(
+    `api:sections:${locale}`,
     `api:sections:${JSON.stringify({ locale, parsedQuery, pagination })}`,
     SECTION_LIST_API_CACHE_TTL_MS,
     () => listUncachedSectionsAction(parsedQuery, pagination, locale),

--- a/src/lib/api/routes/academic-teacher-routes.ts
+++ b/src/lib/api/routes/academic-teacher-routes.ts
@@ -37,6 +37,7 @@ export async function getTeachersRoute(request: Request) {
 
   try {
     const result = await cachedPublicRuntimeData(
+      `api:teachers:${locale}`,
       publicRuntimeCacheKey(`api:teachers:${locale}`, searchParams),
       TEACHERS_API_CACHE_TTL_MS,
       async () => {

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -1,3 +1,4 @@
+import type { AppLocale } from "@/i18n/config";
 import { getCloudflareAnalyticsEngineDataset } from "@/lib/adapters/cloudflare-runtime";
 import type {
   McpRequestSummary,
@@ -66,10 +67,21 @@ type StorageOperationAnalyticsInput = {
   size?: number | null;
 };
 
+export type PublicRuntimeCacheAnalyticsNamespace =
+  | "api:metadata"
+  | "api:semesters"
+  | `${
+      | "api:courses"
+      | "api:sections"
+      | "api:teachers"
+      | "page:course-list"
+      | "page:section-list"
+      | "page:teacher-list"}:${AppLocale}`;
+
 type CacheEventAnalyticsInput = {
   event: "hit" | "load_error" | "load_success" | "miss";
   ioObservedDurationMs: number;
-  key: string;
+  namespace: PublicRuntimeCacheAnalyticsNamespace;
   storeSize: number;
   ttlMs: number;
 };
@@ -122,11 +134,6 @@ function boundedList(values: string[] | undefined) {
 function finiteNumber(value: number | undefined | null) {
   if (typeof value !== "number" || !Number.isFinite(value)) return 0;
   return Math.max(0, value);
-}
-
-function cacheNamespace(key: string) {
-  const [scope, resource, locale] = key.split(":");
-  return [scope, resource, locale].filter(Boolean).map(boundedValue).join(":");
 }
 
 function writeAnalyticsDataPoint(input: {
@@ -270,8 +277,8 @@ export function writeStorageOperationAnalytics(
 
 export function writeCacheEventAnalytics(input: CacheEventAnalyticsInput) {
   writeAnalyticsDataPoint({
-    indexes: [`cache:${boundedValue(cacheNamespace(input.key))}`],
-    blobs: ["public_runtime_cache_v2", input.event, cacheNamespace(input.key)],
+    indexes: [`cache:${boundedValue(input.namespace)}`],
+    blobs: ["public_runtime_cache_v2", input.event, input.namespace],
     doubles: [input.ioObservedDurationMs, input.ttlMs, input.storeSize],
   });
 }

--- a/src/lib/public-runtime-cache.ts
+++ b/src/lib/public-runtime-cache.ts
@@ -1,4 +1,7 @@
-import { writeCacheEventAnalytics } from "@/lib/metrics/analytics-engine";
+import {
+  type PublicRuntimeCacheAnalyticsNamespace,
+  writeCacheEventAnalytics,
+} from "@/lib/metrics/analytics-engine";
 
 type CacheEntry<T> = {
   expiresAt: number;
@@ -42,6 +45,7 @@ export function publicRuntimeCacheKey(
 }
 
 export function cachedPublicRuntimeData<T>(
+  analyticsNamespace: PublicRuntimeCacheAnalyticsNamespace,
   key: string,
   ttlMs: number,
   load: () => Promise<T>,
@@ -56,7 +60,7 @@ export function cachedPublicRuntimeData<T>(
     writeCacheEventAnalytics({
       event: "hit",
       ioObservedDurationMs: Date.now() - start,
-      key,
+      namespace: analyticsNamespace,
       storeSize: store.size,
       ttlMs,
     });
@@ -66,7 +70,7 @@ export function cachedPublicRuntimeData<T>(
   writeCacheEventAnalytics({
     event: "miss",
     ioObservedDurationMs: Date.now() - start,
-    key,
+    namespace: analyticsNamespace,
     storeSize: store.size,
     ttlMs,
   });
@@ -75,7 +79,7 @@ export function cachedPublicRuntimeData<T>(
       writeCacheEventAnalytics({
         event: "load_success",
         ioObservedDurationMs: Date.now() - start,
-        key,
+        namespace: analyticsNamespace,
         storeSize: store.size,
         ttlMs,
       });
@@ -86,7 +90,7 @@ export function cachedPublicRuntimeData<T>(
       writeCacheEventAnalytics({
         event: "load_error",
         ioObservedDurationMs: Date.now() - start,
-        key,
+        namespace: analyticsNamespace,
         storeSize: store.size,
         ttlMs,
       });

--- a/tests/unit/analytics-engine-runtime-events.test.ts
+++ b/tests/unit/analytics-engine-runtime-events.test.ts
@@ -235,27 +235,44 @@ describe("Cloudflare Analytics Engine runtime events", () => {
     );
   });
 
-  it("writes cache datapoints without raw query cache keys", async () => {
+  it.each([
+    {
+      key: "course-list:zh-cn:page=1&search=sensitive-marker-679",
+      namespace: "page:course-list:zh-cn" as const,
+      surface: "catalog page list",
+    },
+    {
+      key: `api:sections:${JSON.stringify({
+        locale: "en-us",
+        pagination: { page: 1, pageSize: 20 },
+        parsedQuery: { search: "sensitive-marker-679" },
+      })}`,
+      namespace: "api:sections:en-us" as const,
+      surface: "section API",
+    },
+  ])("writes explicit $surface cache namespaces without raw query cache keys", async ({
+    key,
+    namespace,
+  }) => {
     const writeDataPoint = installAnalyticsBinding();
     const load = vi.fn(async () => ({ ok: true }));
-    const key = "api:courses:en-us:search=private-query&page=1";
 
-    await cachedPublicRuntimeData(key, 60_000, load);
-    await cachedPublicRuntimeData(key, 60_000, load);
+    await cachedPublicRuntimeData(namespace, key, 60_000, load);
+    await cachedPublicRuntimeData(namespace, key, 60_000, load);
 
     expect(load).toHaveBeenCalledTimes(1);
     expect(writeDataPoint).toHaveBeenCalledWith({
-      indexes: ["cache:api:courses:en-us"],
-      blobs: ["public_runtime_cache_v2", "miss", "api:courses:en-us"],
+      indexes: [`cache:${namespace}`],
+      blobs: ["public_runtime_cache_v2", "miss", namespace],
       doubles: [expect.any(Number), 60_000, 0],
     });
     expect(writeDataPoint).toHaveBeenCalledWith({
-      indexes: ["cache:api:courses:en-us"],
-      blobs: ["public_runtime_cache_v2", "hit", "api:courses:en-us"],
+      indexes: [`cache:${namespace}`],
+      blobs: ["public_runtime_cache_v2", "hit", namespace],
       doubles: [expect.any(Number), 60_000, 1],
     });
     expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain(
-      "private-query",
+      "sensitive-marker-679",
     );
   });
 });

--- a/tests/unit/public-catalog-list-data.test.ts
+++ b/tests/unit/public-catalog-list-data.test.ts
@@ -11,8 +11,13 @@ import { getTeacherListPage } from "@/features/catalog/server/public-teacher-lis
 const mocks = vi.hoisted(() => {
   const findMany = vi.fn().mockResolvedValue([]);
   return {
-    cache: vi.fn((_key: string, _ttlMs: number, load: () => Promise<unknown>) =>
-      load(),
+    cache: vi.fn(
+      (
+        _namespace: string,
+        _key: string,
+        _ttlMs: number,
+        load: () => Promise<unknown>,
+      ) => load(),
     ),
     findMany,
     listCourseSummaries: vi.fn().mockResolvedValue({
@@ -93,8 +98,9 @@ describe("public catalog list loaders", () => {
       locale: "zh-cn",
       pagination: { page: CATALOG_MAX_PAGE, pageSize: 20 },
     });
-    expect(mocks.cache.mock.calls[0]?.[0]).toBe(mocks.cache.mock.calls[1]?.[0]);
-    expect(mocks.cache.mock.calls[0]?.[0]).toMatch(/^page:course-list:zh-cn:/);
+    expect(mocks.cache.mock.calls[0]?.[0]).toBe("page:course-list:zh-cn");
+    expect(mocks.cache.mock.calls[0]?.[1]).toBe(mocks.cache.mock.calls[1]?.[1]);
+    expect(mocks.cache.mock.calls[0]?.[1]).toMatch(/^page:course-list:zh-cn:/);
   });
 
   test("bounds teacher page/search and canonicalizes the ID before querying", async () => {
@@ -112,13 +118,14 @@ describe("public catalog list loaders", () => {
       { nameCn: "asc" },
       "zh-cn",
     );
-    expect(mocks.cache.mock.calls[0]?.[0]).toContain(
+    expect(mocks.cache.mock.calls[0]?.[1]).toContain(
       `page=${CATALOG_MAX_PAGE}`,
     );
-    expect(mocks.cache.mock.calls[0]?.[0]).toContain(
+    expect(mocks.cache.mock.calls[0]?.[1]).toContain(
       `search=${"t".repeat(CATALOG_SEARCH_MAX_LENGTH)}`,
     );
-    expect(mocks.cache.mock.calls[0]?.[0]).toMatch(/^page:teacher-list:zh-cn:/);
+    expect(mocks.cache.mock.calls[0]?.[0]).toBe("page:teacher-list:zh-cn");
+    expect(mocks.cache.mock.calls[0]?.[1]).toMatch(/^page:teacher-list:zh-cn:/);
   });
 
   test("bounds section input and queries from the normalized runtime key", async () => {
@@ -149,9 +156,10 @@ describe("public catalog list loaders", () => {
       locale: "zh-cn",
       pagination: { page: CATALOG_MAX_PAGE, pageSize: 20 },
     });
-    expect(mocks.cache.mock.calls[0]?.[0]).not.toContain("campusId");
-    expect(mocks.cache.mock.calls[0]?.[0]).toContain("courseCode=MATH");
-    expect(mocks.cache.mock.calls[0]?.[0]).toContain("credits=2.5");
-    expect(mocks.cache.mock.calls[0]?.[0]).toMatch(/^page:section-list:zh-cn:/);
+    expect(mocks.cache.mock.calls[0]?.[0]).toBe("page:section-list:zh-cn");
+    expect(mocks.cache.mock.calls[0]?.[1]).not.toContain("campusId");
+    expect(mocks.cache.mock.calls[0]?.[1]).toContain("courseCode=MATH");
+    expect(mocks.cache.mock.calls[0]?.[1]).toContain("credits=2.5");
+    expect(mocks.cache.mock.calls[0]?.[1]).toMatch(/^page:section-list:zh-cn:/);
   });
 });


### PR DESCRIPTION
## Summary

- require every public runtime-cache caller to provide an explicit, low-cardinality analytics namespace
- keep full cache keys (including query/filter values) only inside the bounded in-isolate cache
- cover catalog page lists and all existing public academic API caches with typed safe namespaces
- add regression cases proving a sensitive marker from both a page-list key and a section-API key never reaches Analytics Engine

Closes #679.

## Verification

- `bun run app:prepare`
- `bunx biome check` (one pre-existing static-loader warning)
- `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors / 0 warnings
- all three TypeScript typecheck configs
- `bunx vitest run` — 264 files / 1671 tests
- `bun run build`

No endpoint, schema, cache TTL, lookup key, authorization, or locale behavior changes.