### PR TITLE
perf(ui): lazy-load catalog and section detail client tabs

### DIFF
--- a/src/features/catalog/components/CourseDetailPageController.svelte
+++ b/src/features/catalog/components/CourseDetailPageController.svelte
@@ -209,6 +209,10 @@ $: activeNavItem =
               copy={copy.descriptions}
               showTitle={false}
             />
+          {:else if data.descriptionData.description.renderedHtml}
+            <div class="markdown-preview" data-slot="markdown-preview">
+              {@html data.descriptionData.description.renderedHtml}
+            </div>
           {/if}
         {/key}
       </section>

--- a/src/features/catalog/components/CourseDetailPageController.svelte
+++ b/src/features/catalog/components/CourseDetailPageController.svelte
@@ -3,9 +3,7 @@ import BookOpenTextIcon from "@lucide/svelte/icons/book-open-text";
 import InfoIcon from "@lucide/svelte/icons/info";
 import ListIcon from "@lucide/svelte/icons/list";
 import MessageSquareIcon from "@lucide/svelte/icons/message-square";
-import CommentsPanel from "@/features/comments/components/CommentsPanel.svelte";
 import { commentTargetPermalinkBaseHref } from "@/features/comments/lib/comment-panel-controller";
-import DescriptionCard from "@/features/descriptions/components/DescriptionCard.svelte";
 import DetailSectionNav from "$lib/components/DetailSectionNav.svelte";
 import PageHeader from "$lib/components/PageHeader.svelte";
 import TruncatedCode from "$lib/components/TruncatedCode.svelte";
@@ -72,6 +70,32 @@ type PageData = {
 };
 
 export let data: PageData;
+
+let DescriptionCard:
+  | typeof import("@/features/descriptions/components/DescriptionCard.svelte").default
+  | null = null;
+let CommentsPanel:
+  | typeof import("@/features/comments/components/CommentsPanel.svelte").default
+  | null = null;
+
+async function ensureDescriptionCard() {
+  DescriptionCard ??= (
+    await import("@/features/descriptions/components/DescriptionCard.svelte")
+  ).default;
+}
+
+async function ensureCommentsPanel() {
+  CommentsPanel ??= (
+    await import("@/features/comments/components/CommentsPanel.svelte")
+  ).default;
+}
+
+$: if (data.detailSection === "introduction") {
+  void ensureDescriptionCard();
+}
+$: if (data.detailSection === "comments") {
+  void ensureCommentsPanel();
+}
 
 $: copy = data.copy;
 $: detailCopy = copy satisfies CourseDetailCopy;
@@ -175,14 +199,17 @@ $: activeNavItem =
       {:else if data.detailSection === "introduction"}
       <section id="course-description">
         {#key `description:course:${data.course.id}`}
-          <DescriptionCard
-            targetType="course"
-            targetId={data.course.id}
-            initialData={data.descriptionData}
-            locale={data.locale as "en-us" | "zh-cn"}
-            copy={copy.descriptions}
-            showTitle={false}
-          />
+          {#if DescriptionCard}
+            <svelte:component
+              this={DescriptionCard}
+              targetType="course"
+              targetId={data.course.id}
+              initialData={data.descriptionData}
+              locale={data.locale as "en-us" | "zh-cn"}
+              copy={copy.descriptions}
+              showTitle={false}
+            />
+          {/if}
         {/key}
       </section>
       {:else if data.detailSection === "sections"}
@@ -198,15 +225,18 @@ $: activeNavItem =
       {:else if data.detailSection === "comments"}
       <section id="course-comments">
         {#key `comments:course:${data.course.id}`}
-          <CommentsPanel
-            initialData={data.commentsData}
-            permalinkBaseHref={commentTargetPermalinkBaseHref({
-              courseJwId: data.course.jwId,
-              type: "course",
-            })}
-            targetType="course"
-            targetId={data.course.id}
-          />
+          {#if CommentsPanel}
+            <svelte:component
+              this={CommentsPanel}
+              initialData={data.commentsData}
+              permalinkBaseHref={commentTargetPermalinkBaseHref({
+                courseJwId: data.course.jwId,
+                type: "course",
+              })}
+              targetType="course"
+              targetId={data.course.id}
+            />
+          {/if}
         {/key}
       </section>
       {/if}

--- a/src/features/catalog/components/TeacherDetailPageController.svelte
+++ b/src/features/catalog/components/TeacherDetailPageController.svelte
@@ -198,6 +198,10 @@ $: activeNavItem =
               copy={copy.descriptions}
               showTitle={false}
             />
+          {:else if data.descriptionData.description.renderedHtml}
+            <div class="markdown-preview" data-slot="markdown-preview">
+              {@html data.descriptionData.description.renderedHtml}
+            </div>
           {/if}
         {/key}
       </section>

--- a/src/features/catalog/components/TeacherDetailPageController.svelte
+++ b/src/features/catalog/components/TeacherDetailPageController.svelte
@@ -3,9 +3,7 @@ import BookOpenTextIcon from "@lucide/svelte/icons/book-open-text";
 import InfoIcon from "@lucide/svelte/icons/info";
 import ListIcon from "@lucide/svelte/icons/list";
 import MessageSquareIcon from "@lucide/svelte/icons/message-square";
-import CommentsPanel from "@/features/comments/components/CommentsPanel.svelte";
 import { commentTargetPermalinkBaseHref } from "@/features/comments/lib/comment-panel-controller";
-import DescriptionCard from "@/features/descriptions/components/DescriptionCard.svelte";
 import DetailSectionNav from "$lib/components/DetailSectionNav.svelte";
 import PageHeader from "$lib/components/PageHeader.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
@@ -60,6 +58,32 @@ type PageData = {
 };
 
 export let data: PageData;
+
+let DescriptionCard:
+  | typeof import("@/features/descriptions/components/DescriptionCard.svelte").default
+  | null = null;
+let CommentsPanel:
+  | typeof import("@/features/comments/components/CommentsPanel.svelte").default
+  | null = null;
+
+async function ensureDescriptionCard() {
+  DescriptionCard ??= (
+    await import("@/features/descriptions/components/DescriptionCard.svelte")
+  ).default;
+}
+
+async function ensureCommentsPanel() {
+  CommentsPanel ??= (
+    await import("@/features/comments/components/CommentsPanel.svelte")
+  ).default;
+}
+
+$: if (data.detailSection === "introduction") {
+  void ensureDescriptionCard();
+}
+$: if (data.detailSection === "comments") {
+  void ensureCommentsPanel();
+}
 
 $: copy = data.copy;
 $: detailCopy = copy satisfies TeacherDetailCopy;
@@ -164,14 +188,17 @@ $: activeNavItem =
       {:else if data.detailSection === "introduction"}
       <section id="teacher-description">
         {#key `description:teacher:${data.teacher.id}`}
-          <DescriptionCard
-            targetType="teacher"
-            targetId={data.teacher.id}
-            initialData={data.descriptionData}
-            locale={data.locale as "en-us" | "zh-cn"}
-            copy={copy.descriptions}
-            showTitle={false}
-          />
+          {#if DescriptionCard}
+            <svelte:component
+              this={DescriptionCard}
+              targetType="teacher"
+              targetId={data.teacher.id}
+              initialData={data.descriptionData}
+              locale={data.locale as "en-us" | "zh-cn"}
+              copy={copy.descriptions}
+              showTitle={false}
+            />
+          {/if}
         {/key}
       </section>
       {:else if data.detailSection === "sections"}
@@ -187,15 +214,18 @@ $: activeNavItem =
       {:else if data.detailSection === "comments"}
       <section id="teacher-comments">
         {#key `comments:teacher:${data.teacher.id}`}
-          <CommentsPanel
-            initialData={data.commentsData}
-            permalinkBaseHref={commentTargetPermalinkBaseHref({
-              teacherId: data.teacher.id,
-              type: "teacher",
-            })}
-            targetType="teacher"
-            targetId={data.teacher.id}
-          />
+          {#if CommentsPanel}
+            <svelte:component
+              this={CommentsPanel}
+              initialData={data.commentsData}
+              permalinkBaseHref={commentTargetPermalinkBaseHref({
+                teacherId: data.teacher.id,
+                type: "teacher",
+              })}
+              targetType="teacher"
+              targetId={data.teacher.id}
+            />
+          {/if}
         {/key}
       </section>
       {/if}

--- a/src/features/descriptions/lib/description-empty-payload.ts
+++ b/src/features/descriptions/lib/description-empty-payload.ts
@@ -1,0 +1,26 @@
+import type {
+  DescriptionData,
+  DescriptionPayload,
+  DescriptionViewer,
+} from "./description-payload-types";
+
+export function emptyDescriptionData(): DescriptionData {
+  return {
+    id: null,
+    content: "",
+    renderedHtml: "",
+    updatedAt: null,
+    lastEditedAt: null,
+    lastEditedBy: null,
+  };
+}
+
+export function emptyDescriptionPayload(
+  viewer: DescriptionViewer,
+): DescriptionPayload {
+  return {
+    description: emptyDescriptionData(),
+    history: [],
+    viewer,
+  };
+}

--- a/src/features/descriptions/server/description-payload.ts
+++ b/src/features/descriptions/server/description-payload.ts
@@ -1,8 +1,10 @@
+import {
+  emptyDescriptionData,
+  emptyDescriptionPayload,
+} from "@/features/descriptions/lib/description-empty-payload";
 import type {
   DescriptionData,
   DescriptionHistoryItem,
-  DescriptionPayload,
-  DescriptionViewer,
   EditorSummary,
 } from "@/features/descriptions/lib/description-payload-types";
 import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
@@ -15,6 +17,8 @@ export type {
   DescriptionViewer,
   EditorSummary,
 } from "@/features/descriptions/lib/description-payload-types";
+
+export { emptyDescriptionData, emptyDescriptionPayload };
 
 import { toShanghaiIsoString } from "@/lib/time/serialize-date-output";
 
@@ -35,27 +39,6 @@ type DescriptionHistoryRecord = {
   nextContent?: string | null;
   previousContent?: string | null;
 };
-
-export function emptyDescriptionData(): DescriptionData {
-  return {
-    id: null,
-    content: "",
-    renderedHtml: "",
-    updatedAt: null,
-    lastEditedAt: null,
-    lastEditedBy: null,
-  };
-}
-
-export function emptyDescriptionPayload(
-  viewer: DescriptionViewer,
-): DescriptionPayload {
-  return {
-    description: emptyDescriptionData(),
-    history: [],
-    viewer,
-  };
-}
 
 export function serializeDescriptionRecord(
   description: DescriptionRecord | null | undefined,

--- a/src/features/section-detail/components/SectionDetailDialogs.svelte
+++ b/src/features/section-detail/components/SectionDetailDialogs.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
 import type { SectionDetailPageData } from "@/features/section-detail/lib/section-detail-controller-helpers";
-import SectionCalendarDialog from "./SectionCalendarDialog.svelte";
-import SectionHomeworkDialogs from "./SectionHomeworkDialogs.svelte";
 import SectionSubscribeDialog from "./SectionSubscribeDialog.svelte";
 import type {
   BooleanSetter,
@@ -74,9 +72,40 @@ export let applyEditDueInWeek: SectionDetailDialogsProps["applyEditDueInWeek"];
 export let applyEditPublishNow: SectionDetailDialogsProps["applyEditPublishNow"];
 export let applyEditStartAtSemesterStart: SectionDetailDialogsProps["applyEditStartAtSemesterStart"];
 export let applyEditStartNow: SectionDetailDialogsProps["applyEditStartNow"];
+
+let SectionHomeworkDialogs:
+  | typeof import("./SectionHomeworkDialogs.svelte").default
+  | null = null;
+let SectionCalendarDialog:
+  | typeof import("./SectionCalendarDialog.svelte").default
+  | null = null;
+
+async function ensureSectionHomeworkDialogs() {
+  SectionHomeworkDialogs ??= (await import("./SectionHomeworkDialogs.svelte"))
+    .default;
+}
+
+async function ensureSectionCalendarDialog() {
+  SectionCalendarDialog ??= (await import("./SectionCalendarDialog.svelte"))
+    .default;
+}
+
+$: if (
+  showCreateHomework ||
+  selectedHomework ||
+  deleteHomeworkTarget ||
+  isHomeworkAuditDialogOpen
+) {
+  void ensureSectionHomeworkDialogs();
+}
+$: if (isCalendarDialogOpen) {
+  void ensureSectionCalendarDialog();
+}
 </script>
 
-<SectionHomeworkDialogs
+{#if SectionHomeworkDialogs}
+  <svelte:component
+    this={SectionHomeworkDialogs}
   {applyCreateDueAtSemesterEnd}
   {applyCreateDueInMonth}
   {applyCreateDueInWeek}
@@ -129,9 +158,12 @@ export let applyEditStartNow: SectionDetailDialogsProps["applyEditStartNow"];
   {startEditHomework}
   {toggleHomeworkCompletion}
   {updateHomework}
-/>
+  />
+{/if}
 
-<SectionCalendarDialog
+{#if SectionCalendarDialog}
+  <svelte:component
+    this={SectionCalendarDialog}
   {clipboardError}
   {clipboardMessage}
   close={closeCalendarDialog}
@@ -142,7 +174,8 @@ export let applyEditStartNow: SectionDetailDialogsProps["applyEditStartNow"];
   setOpen={setCalendarDialogOpen}
   {singleCalendarUrl}
   {subscriptionCalendarUrl}
-/>
+  />
+{/if}
 
 {#if showSubscribeDialog && data.section.retiredAt == null}
   <SectionSubscribeDialog

--- a/src/features/section-detail/components/SectionDetailMainContent.svelte
+++ b/src/features/section-detail/components/SectionDetailMainContent.svelte
@@ -256,6 +256,10 @@ $: sectionNavItems = [
               copy={data.copy.descriptions}
               showTitle={false}
             />
+          {:else if descriptionData.description.renderedHtml}
+            <div class="markdown-preview" data-slot="markdown-preview">
+              {@html descriptionData.description.renderedHtml}
+            </div>
           {/if}
         {/key}
       </section>

--- a/src/features/section-detail/components/SectionDetailMainContent.svelte
+++ b/src/features/section-detail/components/SectionDetailMainContent.svelte
@@ -7,8 +7,6 @@ import InfoIcon from "@lucide/svelte/icons/info";
 import MessageSquareIcon from "@lucide/svelte/icons/message-square";
 import UsersIcon from "@lucide/svelte/icons/users";
 import type { SubmitFunction } from "@sveltejs/kit";
-import CommentsPanel from "@/features/comments/components/CommentsPanel.svelte";
-import DescriptionCard from "@/features/descriptions/components/DescriptionCard.svelte";
 import type { SectionDetailPageData } from "@/features/section-detail/lib/section-detail-controller-helpers";
 import type { SectionDetailSection } from "@/features/section-detail/lib/section-detail-controller-types";
 import {
@@ -21,11 +19,8 @@ import { Button } from "$lib/components/ui/button/index.js";
 import { Separator } from "$lib/components/ui/separator/index.js";
 import { cn } from "$lib/utils.js";
 import SectionBasicInfoCard from "./SectionBasicInfoCard.svelte";
-import SectionCalendarTab from "./SectionCalendarTab.svelte";
 import SectionDetailHeader from "./SectionDetailHeader.svelte";
 import SectionDetailPrimaryActions from "./SectionDetailPrimaryActions.svelte";
-import SectionExamSection from "./SectionExamSection.svelte";
-import SectionHomeworkTab from "./SectionHomeworkTab.svelte";
 import SectionTeachersCard from "./SectionTeachersCard.svelte";
 import type {
   BooleanSetter,
@@ -78,6 +73,62 @@ export let todayCalendarMonthOffset: number;
 export let unscheduledCalendarEvents: SectionDetailMainContentProps["unscheduledCalendarEvents"];
 export let viewer: SectionDetailMainContentProps["viewer"];
 export let yesNo: SectionDetailMainContentProps["yesNo"];
+
+let DescriptionCard:
+  | typeof import("@/features/descriptions/components/DescriptionCard.svelte").default
+  | null = null;
+let CommentsPanel:
+  | typeof import("@/features/comments/components/CommentsPanel.svelte").default
+  | null = null;
+let SectionCalendarTab:
+  | typeof import("./SectionCalendarTab.svelte").default
+  | null = null;
+let SectionExamSection:
+  | typeof import("./SectionExamSection.svelte").default
+  | null = null;
+let SectionHomeworkTab:
+  | typeof import("./SectionHomeworkTab.svelte").default
+  | null = null;
+
+async function ensureDescriptionCard() {
+  DescriptionCard ??= (
+    await import("@/features/descriptions/components/DescriptionCard.svelte")
+  ).default;
+}
+
+async function ensureCommentsPanel() {
+  CommentsPanel ??= (
+    await import("@/features/comments/components/CommentsPanel.svelte")
+  ).default;
+}
+
+async function ensureSectionCalendarTab() {
+  SectionCalendarTab ??= (await import("./SectionCalendarTab.svelte")).default;
+}
+
+async function ensureSectionExamSection() {
+  SectionExamSection ??= (await import("./SectionExamSection.svelte")).default;
+}
+
+async function ensureSectionHomeworkTab() {
+  SectionHomeworkTab ??= (await import("./SectionHomeworkTab.svelte")).default;
+}
+
+$: if (activeTab === "introduction") {
+  void ensureDescriptionCard();
+}
+$: if (activeTab === "comments") {
+  void ensureCommentsPanel();
+}
+$: if (activeTab === "calendar") {
+  void ensureSectionCalendarTab();
+}
+$: if (activeTab === "exams") {
+  void ensureSectionExamSection();
+}
+$: if (activeTab === "homework") {
+  void ensureSectionHomeworkTab();
+}
 
 $: sectionExamEvents = sectionCalendarEvents.filter(
   (event) => event.kind === "exam",
@@ -195,56 +246,68 @@ $: sectionNavItems = [
       {:else if activeTab === "introduction"}
       <section id="section-description">
         {#key `description:section:${data.section.id}`}
-          <DescriptionCard
-            targetType="section"
-            targetId={data.section.id}
-            initialData={descriptionData}
-            locale={data.locale}
-            copy={data.copy.descriptions}
-            showTitle={false}
-          />
+          {#if DescriptionCard}
+            <svelte:component
+              this={DescriptionCard}
+              targetType="section"
+              targetId={data.section.id}
+              initialData={descriptionData}
+              locale={data.locale}
+              copy={data.copy.descriptions}
+              showTitle={false}
+            />
+          {/if}
         {/key}
       </section>
       {:else if activeTab === "calendar"}
       <section id="tab-calendar">
-        <SectionCalendarTab
-          bind:calendarMonthOffset
-          calendarGridWeeks={sectionCalendarGridWeeks}
-          {calendarMonthLabel}
-          dateTimePlaceText={displaySection.dateTimePlaceText}
-          {formatMessage}
-          {openCalendarDialog}
-          {sectionCalendarEvents}
-          {sectionCopy}
-          {todayCalendarMonthOffset}
-          {unscheduledCalendarEvents}
-        />
+        {#if SectionCalendarTab}
+          <svelte:component
+            this={SectionCalendarTab}
+            bind:calendarMonthOffset
+            calendarGridWeeks={sectionCalendarGridWeeks}
+            {calendarMonthLabel}
+            dateTimePlaceText={displaySection.dateTimePlaceText}
+            {formatMessage}
+            {openCalendarDialog}
+            {sectionCalendarEvents}
+            {sectionCopy}
+            {todayCalendarMonthOffset}
+            {unscheduledCalendarEvents}
+          />
+        {/if}
       </section>
       {:else if activeTab === "exams"}
       <section id="tab-exams">
-        <SectionExamSection
-          events={sectionExamEvents}
-          {fmtDate}
-          {sectionCopy}
-        />
+        {#if SectionExamSection}
+          <svelte:component
+            this={SectionExamSection}
+            events={sectionExamEvents}
+            {fmtDate}
+            {sectionCopy}
+          />
+        {/if}
       </section>
       {:else if activeTab === "homework"}
       <section id="tab-homework">
-        <SectionHomeworkTab
-          {canWriteHomework}
-          {fmtDateTime}
-          {homeworkCopy}
-          {homeworkStatus}
-          {homeworkView}
-          {homeworks}
-          isAuthenticated={viewer.isAuthenticated ?? viewer.signedIn === true}
-          openAuditDialog={() => setHomeworkAuditDialogOpen(true)}
-          {openCreateHomeworkDialog}
-          {sectionCopy}
-          sectionJwId={data.section.jwId}
-          selectHomework={setSelectedHomework}
-          {setHomeworkView}
-        />
+        {#if SectionHomeworkTab}
+          <svelte:component
+            this={SectionHomeworkTab}
+            {canWriteHomework}
+            {fmtDateTime}
+            {homeworkCopy}
+            {homeworkStatus}
+            {homeworkView}
+            {homeworks}
+            isAuthenticated={viewer.isAuthenticated ?? viewer.signedIn === true}
+            openAuditDialog={() => setHomeworkAuditDialogOpen(true)}
+            {openCreateHomeworkDialog}
+            {sectionCopy}
+            sectionJwId={data.section.jwId}
+            selectHomework={setSelectedHomework}
+            {setHomeworkView}
+          />
+        {/if}
       </section>
       {:else if activeTab === "teachers"}
       <section id="section-teachers">
@@ -258,13 +321,16 @@ $: sectionNavItems = [
       {:else if activeTab === "comments"}
       <section id="tab-comments">
         {#key `comments:section:${data.section.id}`}
-          <CommentsPanel
-            initialData={data.commentsData}
-            targetType="section"
-            targetId={data.section.id}
-            targets={commentTargets}
-            showAllTargets
-          />
+          {#if CommentsPanel}
+            <svelte:component
+              this={CommentsPanel}
+              initialData={data.commentsData}
+              targetType="section"
+              targetId={data.section.id}
+              targets={commentTargets}
+              showAllTargets
+            />
+          {/if}
         {/key}
       </section>
       {/if}

--- a/src/features/section-detail/lib/section-detail-tab-client.ts
+++ b/src/features/section-detail/lib/section-detail-tab-client.ts
@@ -1,8 +1,8 @@
 import type { CommentsInitialData } from "@/features/comments/lib/comment-panel-data";
 import type { DescriptionPayload } from "@/features/descriptions/lib/description-card-actions";
 import { fetchDescriptionPayload } from "@/features/descriptions/lib/description-card-client";
+import { emptyDescriptionPayload } from "@/features/descriptions/lib/description-empty-payload";
 import type { DescriptionViewer } from "@/features/descriptions/lib/description-payload-types";
-import { emptyDescriptionPayload } from "@/features/descriptions/server/description-payload";
 import type { AppLocale } from "@/i18n/config";
 import { apiClient } from "@/lib/api/client";
 import { loadSectionHomeworks } from "./homeworks";


### PR DESCRIPTION
## Summary
- Lazy-load `CommentsPanel`, `DescriptionCard`, calendar, homework, and dialog components on catalog course/teacher and section detail routes using the same dynamic-import pattern as `GlobalSearchDialog` (#713).
- Extract `emptyDescriptionPayload` into a markdown-free client module so the section tab-panel store no longer pulls the remark/rehype graph into the overview hydration bundle.

## Budget impact (gzip bytes / limit)
| Route | Before | After |
| --- | --- | --- |
| `/` | 157,829 / 170,000 | 157,843 / 170,000 |
| `/catalog/courses/[jwId]` | 304,791 / 330,000 | 175,590 / 330,000 |
| `/catalog/sections/[jwId]` | 364,699 / 390,000 | 226,973 / 390,000 |

## Test plan
- [x] `bun run build`
- [x] `tests/ci/public-route-client-budget.test.sh`
- [x] `bunx biome check`
- [x] `bunx vitest run`