### PR TITLE
feat(data): add Comment collaborative RLS policies

### DIFF
--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -236,6 +236,9 @@ jobs:
                 tests/integration/comment-reaction-rls.test.ts
               bunx vitest run \
                 --config vitest.integration.config.ts \
+                tests/integration/comment-rls.test.ts
+              bunx vitest run \
+                --config vitest.integration.config.ts \
                 tests/integration/upload-rls.test.ts
               bunx vitest run \
                 --config vitest.integration.config.ts \

--- a/prisma/migrations/20260801120000_comment_collaborative_rls/migration.sql
+++ b/prisma/migrations/20260801120000_comment_collaborative_rls/migration.sql
@@ -1,0 +1,65 @@
+BEGIN;
+
+ALTER TABLE "Comment" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Comment" FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY "Comment_public_reader" ON "Comment"
+  FOR SELECT
+  USING (
+    "status" = 'active'
+    AND "visibility" = 'public'
+  );
+
+CREATE POLICY "Comment_authenticated_reader" ON "Comment"
+  FOR SELECT
+  USING (
+    NULLIF(current_setting('app.user_id', true), '') IS NOT NULL
+    AND (
+      "status" = 'active'
+      OR (
+        "status" = 'softbanned'
+        AND "userId" = NULLIF(current_setting('app.user_id', true), '')
+      )
+    )
+  );
+
+CREATE POLICY "Comment_admin_reader" ON "Comment"
+  FOR SELECT
+  USING (
+    NULLIF(current_setting('app.user_id', true), '') IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM public."User" AS app_user
+      WHERE app_user."id" = NULLIF(current_setting('app.user_id', true), '')
+        AND app_user."isAdmin" IS TRUE
+    )
+    AND "status" IN ('active', 'softbanned', 'deleted')
+  );
+
+CREATE POLICY "Comment_owner_isolation" ON "Comment"
+  FOR ALL
+  USING ("userId" = NULLIF(current_setting('app.user_id', true), ''))
+  WITH CHECK ("userId" = NULLIF(current_setting('app.user_id', true), ''));
+
+CREATE POLICY "Comment_admin_moderator" ON "Comment"
+  FOR UPDATE
+  USING (
+    NULLIF(current_setting('app.user_id', true), '') IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM public."User" AS app_user
+      WHERE app_user."id" = NULLIF(current_setting('app.user_id', true), '')
+        AND app_user."isAdmin" IS TRUE
+    )
+  )
+  WITH CHECK (
+    NULLIF(current_setting('app.user_id', true), '') IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM public."User" AS app_user
+      WHERE app_user."id" = NULLIF(current_setting('app.user_id', true), '')
+        AND app_user."isAdmin" IS TRUE
+    )
+  );
+
+COMMIT;

--- a/prisma/migrations/20260801120000_comment_collaborative_rls/migration.sql
+++ b/prisma/migrations/20260801120000_comment_collaborative_rls/migration.sql
@@ -62,4 +62,30 @@ CREATE POLICY "Comment_admin_moderator" ON "Comment"
     )
   );
 
+CREATE FUNCTION public.comment_hidden_root_count(
+  p_section_id integer DEFAULT NULL,
+  p_course_id integer DEFAULT NULL,
+  p_teacher_id integer DEFAULT NULL,
+  p_homework_id text DEFAULT NULL,
+  p_section_teacher_id integer DEFAULT NULL
+) RETURNS bigint
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+  SELECT COUNT(*)::bigint
+  FROM public."Comment"
+  WHERE "parentId" IS NULL
+    AND "status" = 'active'
+    AND "visibility" = 'logged_in_only'
+    AND (
+      (p_section_id IS NOT NULL AND "sectionId" = p_section_id)
+      OR (p_course_id IS NOT NULL AND "courseId" = p_course_id)
+      OR (p_teacher_id IS NOT NULL AND "teacherId" = p_teacher_id)
+      OR (p_homework_id IS NOT NULL AND "homeworkId" = p_homework_id)
+      OR (p_section_teacher_id IS NOT NULL AND "sectionTeacherId" = p_section_teacher_id)
+    );
+$function$;
+
 COMMIT;

--- a/prisma/roles/app-runtime-table-grants.sql
+++ b/prisma/roles/app-runtime-table-grants.sql
@@ -50,7 +50,7 @@ TO life_ustc_runtime;
 GRANT SELECT, INSERT, DELETE ON TABLE "CommentReaction"
 TO life_ustc_runtime;
 
-GRANT INSERT, UPDATE ON TABLE "Comment" TO life_ustc_runtime;
+GRANT SELECT, INSERT, UPDATE ON TABLE "Comment" TO life_ustc_runtime;
 GRANT INSERT, DELETE ON TABLE "CommentAttachment" TO life_ustc_runtime;
 GRANT INSERT, UPDATE ON TABLE "Homework" TO life_ustc_runtime;
 GRANT INSERT ON TABLE "HomeworkAuditLog" TO life_ustc_runtime;

--- a/prisma/roles/production-runtime-bootstrap.sql
+++ b/prisma/roles/production-runtime-bootstrap.sql
@@ -319,6 +319,7 @@ GRANT EXECUTE ON FUNCTION
   public.comment_attachment_summaries(text[]),
   public.get_public_profile_upload_stats(text, timestamp without time zone),
   public.comment_reaction_summaries(text[]),
+  public.comment_hidden_root_count(integer, integer, integer, text, integer),
   public.get_public_profile_homework_completions(text, timestamp without time zone),
   public.get_public_profile_section_subscription_count(text)
 TO life_ustc_runtime;

--- a/src/features/admin/server/admin-api-service.ts
+++ b/src/features/admin/server/admin-api-service.ts
@@ -3,7 +3,7 @@ import { DESCRIPTION_CONTENT_MAX_LENGTH } from "@/features/descriptions/lib/desc
 import { isValidProfileUsername } from "@/features/profile/lib/profile-username";
 import type { CommentStatus } from "@/generated/prisma/client";
 import { writeAuditLog } from "@/lib/audit/write-audit-log";
-import { prisma } from "@/lib/db/prisma";
+import { prisma, withUserDbContext } from "@/lib/db/prisma";
 import { isPrismaUniqueConstraintError } from "@/lib/db/prisma-errors";
 import { runSerializableTransaction } from "@/lib/db/serializable-transaction";
 import { parseDateInput } from "@/lib/time/parse-date-input";
@@ -280,7 +280,7 @@ export async function moderateComment(
   input: AdminModerateCommentInput,
 ) {
   const { status, moderationNote } = input;
-  const result = await prisma.$transaction(async (tx) => {
+  const result = await withUserDbContext(adminUserId, async (tx) => {
     const existing = await tx.comment.findUnique({
       where: { id },
       select: { id: true },

--- a/src/features/admin/server/admin-home-page-data.ts
+++ b/src/features/admin/server/admin-home-page-data.ts
@@ -3,10 +3,10 @@ import {
   requireAdminPage,
 } from "@/features/admin/server/admin-page-auth";
 import { authPrisma } from "@/lib/db/auth-prisma";
-import { getPrisma } from "@/lib/db/prisma";
+import { getPrisma, withUserDbContext } from "@/lib/db/prisma";
 
 export async function getAdminHomeData(request: Request) {
-  await requireAdminPage(request);
+  const admin = await requireAdminPage(request);
   const prisma = await getPrismaClient();
   const [
     users,
@@ -17,16 +17,18 @@ export async function getAdminHomeData(request: Request) {
     oauthClients,
     suspensions,
     busVersions,
-  ] = await Promise.all([
-    prisma.user.count(),
-    prisma.comment.count(),
-    prisma.comment.count({ where: { status: "active" } }),
-    prisma.comment.count({ where: { status: "deleted" } }),
-    prisma.homework.count({ where: { deletedAt: null } }),
-    authPrisma.oAuthClient.count(),
-    prisma.userSuspension.count({ where: { liftedAt: null } }),
-    prisma.busScheduleVersion.count(),
-  ]);
+  ] = await withUserDbContext(admin.id, (tx) =>
+    Promise.all([
+      prisma.user.count(),
+      tx.comment.count(),
+      tx.comment.count({ where: { status: "active" } }),
+      tx.comment.count({ where: { status: "deleted" } }),
+      prisma.homework.count({ where: { deletedAt: null } }),
+      authPrisma.oAuthClient.count(),
+      prisma.userSuspension.count({ where: { liftedAt: null } }),
+      prisma.busScheduleVersion.count(),
+    ]),
+  );
 
   return {
     summary: {

--- a/src/features/admin/server/admin-moderation-api-lists.ts
+++ b/src/features/admin/server/admin-moderation-api-lists.ts
@@ -1,5 +1,5 @@
 import type { AdminCommentStatusFilter } from "@/features/admin/lib/admin-moderation-filters";
-import { prisma } from "@/lib/db/prisma";
+import { prisma, withUserDbContext } from "@/lib/db/prisma";
 import {
   adminDescriptionInclude,
   buildAdminDescriptionWhere,
@@ -11,58 +11,62 @@ import {
 import { buildCommentWhere } from "./admin-moderation-page-filters";
 
 export async function listAdminModerationComments({
+  adminUserId,
   pageSize,
   skip,
   status,
 }: {
+  adminUserId: string;
   pageSize: number;
   skip: number;
   status: AdminCommentStatusFilter;
 }) {
   const where = buildCommentWhere(status);
 
-  const [data, total] = await Promise.all([
-    prisma.comment.findMany({
-      where,
-      include: {
-        user: { select: { name: true } },
-        section: {
-          select: {
-            jwId: true,
-            code: true,
-            course: { select: { jwId: true, code: true, nameCn: true } },
-          },
-        },
-        course: { select: { jwId: true, code: true, nameCn: true } },
-        teacher: { select: { id: true, nameCn: true } },
-        homework: {
-          select: {
-            id: true,
-            title: true,
-            section: { select: { code: true, jwId: true } },
-          },
-        },
-        sectionTeacher: {
-          select: {
-            section: {
-              select: {
-                jwId: true,
-                code: true,
-                course: { select: { jwId: true, code: true, nameCn: true } },
-              },
+  return withUserDbContext(adminUserId, async (tx) => {
+    const [data, total] = await Promise.all([
+      tx.comment.findMany({
+        where,
+        include: {
+          user: { select: { name: true } },
+          section: {
+            select: {
+              jwId: true,
+              code: true,
+              course: { select: { jwId: true, code: true, nameCn: true } },
             },
-            teacher: { select: { nameCn: true } },
+          },
+          course: { select: { jwId: true, code: true, nameCn: true } },
+          teacher: { select: { id: true, nameCn: true } },
+          homework: {
+            select: {
+              id: true,
+              title: true,
+              section: { select: { code: true, jwId: true } },
+            },
+          },
+          sectionTeacher: {
+            select: {
+              section: {
+                select: {
+                  jwId: true,
+                  code: true,
+                  course: { select: { jwId: true, code: true, nameCn: true } },
+                },
+              },
+              teacher: { select: { nameCn: true } },
+            },
           },
         },
-      },
-      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-      skip,
-      take: pageSize,
-    }),
-    prisma.comment.count({ where }),
-  ]);
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+        skip,
+        take: pageSize,
+      }),
+      tx.comment.count({ where }),
+    ]);
 
-  return { data, total };
+    return { data, total };
+  });
 }
 
 export async function listAdminModerationDescriptions({

--- a/src/features/admin/server/admin-moderation-page-data.ts
+++ b/src/features/admin/server/admin-moderation-page-data.ts
@@ -15,13 +15,14 @@ const MODERATION_PAGE_SIZE = 50;
 const MODERATION_DESCRIPTION_PAGE_SIZE = 200;
 
 export async function getAdminModerationPage(request: Request, url: URL) {
-  await requireAdminPage(request);
+  const admin = await requireAdminPage(request);
   const prisma = await getPrismaClient();
   const { tab, search, status, descriptionContent, descriptionTarget } =
     getModerationFilters(url);
 
   const [comments, descriptions, homeworks, suspensions] =
     await getAdminModerationReadData({
+      adminUserId: admin.id,
       commentWhere: buildCommentWhere(status),
       descriptionPageSize: MODERATION_DESCRIPTION_PAGE_SIZE,
       descriptionWhere: buildDescriptionWhere(

--- a/src/features/admin/server/admin-moderation-read-data.ts
+++ b/src/features/admin/server/admin-moderation-read-data.ts
@@ -4,8 +4,10 @@ import { listModerationHomeworks } from "@/features/admin/server/admin-moderatio
 import { listModerationSuspensions } from "@/features/admin/server/admin-moderation-suspension-read-data";
 import type { AdminModerationPrisma } from "@/features/admin/server/admin-moderation-types";
 import type { Prisma } from "@/generated/prisma/client";
+import { withUserDbContext } from "@/lib/db/prisma";
 
 export async function getAdminModerationReadData({
+  adminUserId,
   commentWhere,
   descriptionWhere,
   homeworkWhere,
@@ -13,6 +15,7 @@ export async function getAdminModerationReadData({
   descriptionPageSize,
   prisma,
 }: {
+  adminUserId: string;
   commentWhere: Prisma.CommentWhereInput;
   descriptionWhere: Prisma.DescriptionWhereInput;
   homeworkWhere: Prisma.HomeworkWhereInput;
@@ -20,8 +23,12 @@ export async function getAdminModerationReadData({
   descriptionPageSize: number;
   prisma: AdminModerationPrisma;
 }) {
+  const comments = await withUserDbContext(adminUserId, (tx) =>
+    listModerationComments({ commentWhere, pageSize, prisma: tx }),
+  );
+
   return Promise.all([
-    listModerationComments({ commentWhere, pageSize, prisma }),
+    Promise.resolve(comments),
     listModerationDescriptions({
       descriptionPageSize,
       descriptionWhere,

--- a/src/features/admin/server/admin-moderation-read-data.ts
+++ b/src/features/admin/server/admin-moderation-read-data.ts
@@ -24,7 +24,11 @@ export async function getAdminModerationReadData({
   prisma: AdminModerationPrisma;
 }) {
   const comments = await withUserDbContext(adminUserId, (tx) =>
-    listModerationComments({ commentWhere, pageSize, prisma: tx }),
+    listModerationComments({
+      commentWhere,
+      pageSize,
+      prisma: tx as AdminModerationPrisma,
+    }),
   );
 
   return Promise.all([

--- a/src/features/calendar/server/calendar-event-sources.ts
+++ b/src/features/calendar/server/calendar-event-sources.ts
@@ -63,7 +63,7 @@ export async function loadCalendarEventSources({
 
   return {
     exams,
-    homeworkItems: await withHomeworkItemState(homeworks),
+    homeworkItems: await withHomeworkItemState(homeworks, userId),
     schedules,
     todos,
   };

--- a/src/features/comments/server/comment-db-context.ts
+++ b/src/features/comments/server/comment-db-context.ts
@@ -1,0 +1,15 @@
+import type { Prisma } from "@/generated/prisma/client";
+import { prisma, withUserDbContext } from "@/lib/db/prisma";
+
+export type CommentDbClient = Pick<Prisma.TransactionClient, "comment">;
+
+export async function withCommentDbContext<T>(
+  viewerUserId: string | null,
+  action: (client: CommentDbClient) => Promise<T>,
+): Promise<T> {
+  if (viewerUserId) {
+    return withUserDbContext(viewerUserId, action);
+  }
+
+  return action(prisma);
+}

--- a/src/features/comments/server/comment-mutations.ts
+++ b/src/features/comments/server/comment-mutations.ts
@@ -5,8 +5,9 @@ import type {
 } from "@/generated/prisma/client";
 import { writeAuditLog } from "@/lib/audit/write-audit-log";
 import { getViewerContext } from "@/lib/auth/viewer-context";
-import { prisma, withUserDbContext } from "@/lib/db/prisma";
+import { withUserDbContext } from "@/lib/db/prisma";
 import { isPrismaUniqueConstraintError } from "@/lib/db/prisma-errors";
+import { withCommentDbContext } from "./comment-db-context";
 import { canViewerWriteCommentInteraction } from "./comment-interaction-policy";
 import {
   commentThreadInclude,
@@ -168,7 +169,7 @@ async function createCommentRecord({
   viewer: ViewerInfo;
   visibility: CommentVisibility;
 }) {
-  return prisma.$transaction(async (tx) => {
+  return withUserDbContext(userId, async (tx) => {
     const parent = await resolveCreateCommentParentForWrite({
       parentId,
       tx,
@@ -254,7 +255,7 @@ export async function updateOwnComment({
 
   let updated = false;
   try {
-    await prisma.$transaction(async (tx) => {
+    await withUserDbContext(userId, async (tx) => {
       const result = await tx.comment.updateMany({
         where: { id, status: "active", userId },
         data: {
@@ -302,10 +303,12 @@ export async function deleteOwnComment(input: {
   const actor = await loadActiveCommentActor(input.userId);
   if (!actor.ok) return actor;
 
-  const comment = await prisma.comment.findUnique({
-    where: { id: input.commentId },
-    select: { id: true, status: true, userId: true, visibility: true },
-  });
+  const comment = await withCommentDbContext(input.userId, (client) =>
+    client.comment.findUnique({
+      where: { id: input.commentId },
+      select: { id: true, status: true, userId: true, visibility: true },
+    }),
+  );
 
   if (!comment) {
     return { ok: false as const, error: "not_found" as const };
@@ -319,7 +322,7 @@ export async function deleteOwnComment(input: {
     return { ok: false as const, error: "locked" as const };
   }
 
-  const deleted = await prisma.$transaction(async (tx) => {
+  const deleted = await withUserDbContext(input.userId, async (tx) => {
     const result = await tx.comment.updateMany({
       where: { id: input.commentId, status: "active", userId: input.userId },
       data: {
@@ -358,10 +361,12 @@ export async function createCommentReaction(input: {
   const actor = await loadActiveCommentActor(input.userId);
   if (!actor.ok) return actor;
 
-  const comment = await prisma.comment.findUnique({
-    where: { id: input.commentId },
-    select: { id: true, status: true, visibility: true },
-  });
+  const comment = await withCommentDbContext(input.userId, (client) =>
+    client.comment.findUnique({
+      where: { id: input.commentId },
+      select: { id: true, status: true, visibility: true },
+    }),
+  );
 
   if (!comment) {
     return { ok: false as const, error: "not_found" as const };
@@ -407,10 +412,12 @@ export async function deleteCommentReaction(input: {
   const actor = await loadActiveCommentActor(input.userId);
   if (!actor.ok) return actor;
 
-  const comment = await prisma.comment.findUnique({
-    where: { id: input.commentId },
-    select: { id: true, status: true, visibility: true },
-  });
+  const comment = await withCommentDbContext(input.userId, (client) =>
+    client.comment.findUnique({
+      where: { id: input.commentId },
+      select: { id: true, status: true, visibility: true },
+    }),
+  );
 
   if (!comment) {
     return { ok: true as const, changed: false };
@@ -567,10 +574,12 @@ async function loadOwnActiveCommentFailure({
   userId: string;
   viewer: ViewerInfo;
 }): Promise<CommentMutationFailure> {
-  const comment = await prisma.comment.findUnique({
-    where: { id },
-    select: { id: true, status: true, userId: true, visibility: true },
-  });
+  const comment = await withCommentDbContext(userId, (client) =>
+    client.comment.findUnique({
+      where: { id },
+      select: { id: true, status: true, userId: true, visibility: true },
+    }),
+  );
 
   if (!comment) {
     return { ok: false, error: "not_found" };
@@ -602,10 +611,12 @@ async function loadEditableCommentContext({
     return { ok: false, error: "suspended", reason: viewer.suspensionReason };
   }
 
-  const comment = await prisma.comment.findUnique({
-    where: { id },
-    select: { id: true, status: true, userId: true },
-  });
+  const comment = await withCommentDbContext(userId, (client) =>
+    client.comment.findUnique({
+      where: { id },
+      select: { id: true, status: true, userId: true },
+    }),
+  );
 
   if (!comment) {
     return { ok: false, error: "not_found" };
@@ -679,10 +690,12 @@ async function syncCommentAttachments(
 }
 
 async function loadCommentResponse(id: string, viewer: ViewerInfo) {
-  const updatedComment = await prisma.comment.findUnique({
-    where: { id },
-    include: commentThreadInclude,
-  });
+  const updatedComment = await withCommentDbContext(viewer.userId, (client) =>
+    client.comment.findUnique({
+      where: { id },
+      include: commentThreadInclude,
+    }),
+  );
 
   if (!updatedComment) return null;
   const commentsWithMetadata = await withCommentReadMetadata(

--- a/src/features/comments/server/comment-read-model.ts
+++ b/src/features/comments/server/comment-read-model.ts
@@ -256,6 +256,34 @@ function directlyVisibleCommentWhere(
   };
 }
 
+async function countAnonymousHiddenRoots(
+  whereTarget: Record<string, number | string>,
+): Promise<number> {
+  const sectionId =
+    typeof whereTarget.sectionId === "number" ? whereTarget.sectionId : null;
+  const courseId =
+    typeof whereTarget.courseId === "number" ? whereTarget.courseId : null;
+  const teacherId =
+    typeof whereTarget.teacherId === "number" ? whereTarget.teacherId : null;
+  const homeworkId =
+    typeof whereTarget.homeworkId === "string" ? whereTarget.homeworkId : null;
+  const sectionTeacherId =
+    typeof whereTarget.sectionTeacherId === "number"
+      ? whereTarget.sectionTeacherId
+      : null;
+
+  const [row] = await prisma.$queryRaw<{ count: bigint }[]>`
+    SELECT public.comment_hidden_root_count(
+      ${sectionId},
+      ${courseId},
+      ${teacherId},
+      ${homeworkId},
+      ${sectionTeacherId}
+    ) AS count
+  `;
+  return Number(row?.count ?? 0);
+}
+
 export async function loadCommentThread(input: {
   pagination?: { pageSize: number; skip: number };
   target: ResolvedCommentTarget;
@@ -304,15 +332,7 @@ export async function loadCommentThread(input: {
           }),
           viewer.isAuthenticated
             ? Promise.resolve(0)
-            : client.comment.count({
-                where: {
-                  AND: [
-                    input.target.whereTarget,
-                    { visibility: "logged_in_only" },
-                    { status: { not: "deleted" } },
-                  ],
-                },
-              }),
+            : countAnonymousHiddenRoots(input.target.whereTarget),
         ]),
     );
     const rootIds = rootComments.map((comment) => comment.id);

--- a/src/features/comments/server/comment-read-model.ts
+++ b/src/features/comments/server/comment-read-model.ts
@@ -289,6 +289,7 @@ export async function loadCommentThread(input: {
         },
       ],
     } satisfies Prisma.CommentWhereInput;
+    const pagination = input.pagination;
     const [total, rootComments, hiddenCount] = await withCommentDbContext(
       input.viewerUserId,
       (client) =>
@@ -297,8 +298,8 @@ export async function loadCommentThread(input: {
           client.comment.findMany({
             where: rootWhere,
             orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-            skip: input.pagination.skip,
-            take: input.pagination.pageSize,
+            skip: pagination.skip,
+            take: pagination.pageSize,
             select: { id: true },
           }),
           viewer.isAuthenticated

--- a/src/features/comments/server/comment-read-model.ts
+++ b/src/features/comments/server/comment-read-model.ts
@@ -5,6 +5,7 @@ import {
 } from "@/lib/auth/viewer-context";
 import { authPrisma } from "@/lib/db/auth-prisma";
 import { prisma, withUserDbContext } from "@/lib/db/prisma";
+import { withCommentDbContext } from "./comment-db-context";
 import {
   buildCommentNodes,
   type CommentNode,
@@ -288,41 +289,49 @@ export async function loadCommentThread(input: {
         },
       ],
     } satisfies Prisma.CommentWhereInput;
-    const [total, rootComments, hiddenCount] = await Promise.all([
-      prisma.comment.count({ where: rootWhere }),
-      prisma.comment.findMany({
-        where: rootWhere,
-        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-        skip: input.pagination.skip,
-        take: input.pagination.pageSize,
-        select: { id: true },
-      }),
-      viewer.isAuthenticated
-        ? Promise.resolve(0)
-        : prisma.comment.count({
-            where: {
-              AND: [
-                input.target.whereTarget,
-                { visibility: "logged_in_only" },
-                { status: { not: "deleted" } },
-              ],
-            },
+    const [total, rootComments, hiddenCount] = await withCommentDbContext(
+      input.viewerUserId,
+      (client) =>
+        Promise.all([
+          client.comment.count({ where: rootWhere }),
+          client.comment.findMany({
+            where: rootWhere,
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+            skip: input.pagination.skip,
+            take: input.pagination.pageSize,
+            select: { id: true },
           }),
-    ]);
+          viewer.isAuthenticated
+            ? Promise.resolve(0)
+            : client.comment.count({
+                where: {
+                  AND: [
+                    input.target.whereTarget,
+                    { visibility: "logged_in_only" },
+                    { status: { not: "deleted" } },
+                  ],
+                },
+              }),
+        ]),
+    );
     const rootIds = rootComments.map((comment) => comment.id);
     const comments =
       rootIds.length === 0
         ? []
-        : await prisma.comment.findMany({
-            where: {
-              AND: [
-                input.target.whereTarget,
-                { OR: [{ id: { in: rootIds } }, { rootId: { in: rootIds } }] },
-              ],
-            },
-            include: commentThreadInclude,
-            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-          });
+        : await withCommentDbContext(input.viewerUserId, (client) =>
+            client.comment.findMany({
+              where: {
+                AND: [
+                  input.target.whereTarget,
+                  {
+                    OR: [{ id: { in: rootIds } }, { rootId: { in: rootIds } }],
+                  },
+                ],
+              },
+              include: commentThreadInclude,
+              orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+            }),
+          );
 
     const commentsWithMetadata = await withCommentReadMetadata(
       comments,
@@ -336,11 +345,13 @@ export async function loadCommentThread(input: {
     input.viewer
       ? Promise.resolve(input.viewer)
       : getViewerContext({ includeAdmin: false, userId: input.viewerUserId }),
-    prisma.comment.findMany({
-      where: input.target.whereTarget,
-      include: commentThreadInclude,
-      orderBy: { createdAt: "asc" },
-    }),
+    withCommentDbContext(input.viewerUserId, (client) =>
+      client.comment.findMany({
+        where: input.target.whereTarget,
+        include: commentThreadInclude,
+        orderBy: { createdAt: "asc" },
+      }),
+    ),
   ]);
 
   const commentsWithMetadata = await withCommentReadMetadata(
@@ -359,10 +370,12 @@ export async function loadFocusedCommentThread(input: {
   viewerUserId: string | null;
 }) {
   const [comment, viewer] = await Promise.all([
-    prisma.comment.findUnique({
-      where: { id: input.commentId },
-      select: commentTargetLookupSelect,
-    }),
+    withCommentDbContext(input.viewerUserId, (client) =>
+      client.comment.findUnique({
+        where: { id: input.commentId },
+        select: commentTargetLookupSelect,
+      }),
+    ),
     getViewerContext({
       includeAdmin: false,
       userId: input.viewerUserId,
@@ -374,13 +387,17 @@ export async function loadFocusedCommentThread(input: {
   }
 
   const threadKey = comment.rootId ?? comment.id;
-  const threadComments = await prisma.comment.findMany({
-    where: {
-      OR: [{ id: threadKey }, { rootId: threadKey }],
-    },
-    include: commentThreadInclude,
-    orderBy: { createdAt: "asc" },
-  });
+  const threadComments = await withCommentDbContext(
+    input.viewerUserId,
+    (client) =>
+      client.comment.findMany({
+        where: {
+          OR: [{ id: threadKey }, { rootId: threadKey }],
+        },
+        include: commentThreadInclude,
+        orderBy: { createdAt: "asc" },
+      }),
+  );
 
   const commentsWithMetadata = await withCommentReadMetadata(
     threadComments,

--- a/src/features/dashboard/server/compact-overview-read-model.ts
+++ b/src/features/dashboard/server/compact-overview-read-model.ts
@@ -189,7 +189,7 @@ export async function getCompactOverview(
   ]);
 
   const dueSoonHomeworks = await runOverviewStage("item_state", () =>
-    withHomeworkItemState(dueSoonHomeworksRaw),
+    withHomeworkItemState(dueSoonHomeworksRaw, userId),
   );
 
   return {

--- a/src/features/homeworks/server/homework-item-state.ts
+++ b/src/features/homeworks/server/homework-item-state.ts
@@ -1,4 +1,4 @@
-import { prisma } from "@/lib/db/prisma";
+import { withCommentDbContext } from "@/features/comments/server/comment-db-context";
 
 type HomeworkCompletionRecord = {
   completedAt: Date;
@@ -17,19 +17,24 @@ export type HomeworkItemWithState<T extends HomeworkWithOptionalCompletions> =
 
 export async function withHomeworkItemState<
   T extends HomeworkWithOptionalCompletions,
->(homeworks: T[]): Promise<Array<HomeworkItemWithState<T>>> {
+>(
+  homeworks: T[],
+  viewerUserId: string | null = null,
+): Promise<Array<HomeworkItemWithState<T>>> {
   if (homeworks.length === 0) {
     return [];
   }
 
-  const commentCountRows = await prisma.comment.groupBy({
-    by: ["homeworkId"],
-    where: {
-      homeworkId: { in: homeworks.map((homework) => homework.id) },
-      status: { not: "deleted" },
-    },
-    _count: { _all: true },
-  });
+  const commentCountRows = await withCommentDbContext(viewerUserId, (client) =>
+    client.comment.groupBy({
+      by: ["homeworkId"],
+      where: {
+        homeworkId: { in: homeworks.map((homework) => homework.id) },
+        status: { not: "deleted" },
+      },
+      _count: { _all: true },
+    }),
+  );
 
   const commentCounts = new Map(
     commentCountRows.flatMap((row: (typeof commentCountRows)[number]) =>

--- a/src/features/subscriptions/server/subscription-homework-page.ts
+++ b/src/features/subscriptions/server/subscription-homework-page.ts
@@ -65,6 +65,6 @@ export async function listSubscribedHomeworkPage(
 
   return {
     ...page,
-    data: await withHomeworkItemState(orderedHomeworks),
+    data: await withHomeworkItemState(orderedHomeworks, userId),
   };
 }

--- a/src/lib/api/routes/admin-comments-list-route.ts
+++ b/src/lib/api/routes/admin-comments-list-route.ts
@@ -28,6 +28,7 @@ export async function getAdminCommentsRoute(request: Request) {
       const { query: parsedQuery, pagination } = parsed;
       const status = normalizeAdminCommentStatusFilter(parsedQuery.status);
       const result = await listAdminModerationComments({
+        adminUserId: admin.userId,
         pageSize: pagination.pageSize,
         skip: pagination.skip,
         status,

--- a/src/lib/api/routes/admin-comments-list-route.ts
+++ b/src/lib/api/routes/admin-comments-list-route.ts
@@ -13,7 +13,7 @@ export async function getAdminCommentsRoute(request: Request) {
   return withAdminApiRoute(
     request,
     "Failed to fetch moderation queue",
-    async () => {
+    async (admin) => {
       const parsed = parseRouteQuery(
         getRequestSearchParams(request),
         adminCommentsQuerySchema,

--- a/src/lib/api/routes/homework-subscribed-read-route.ts
+++ b/src/lib/api/routes/homework-subscribed-read-route.ts
@@ -73,7 +73,7 @@ export async function getSubscribedHomeworksRoute(request: Request) {
         "homeworks",
         "item_state",
         { request },
-        () => withHomeworkItemState(homeworks),
+        () => withHomeworkItemState(homeworks, userId),
       );
 
       return jsonResponse({

--- a/src/lib/log/workspace-route-attribution.ts
+++ b/src/lib/log/workspace-route-attribution.ts
@@ -107,11 +107,35 @@ function logWorkspaceRouteStage(input: {
   );
 }
 
+function writeWorkspaceRouteStageAnalyticsForRoute(input: {
+  ioObservedDurationMs: number;
+  route: WorkspaceRouteName;
+  stage: WorkspaceRouteStage;
+  status: "error" | "success";
+}) {
+  if (input.route === "homeworks") {
+    writeWorkspaceRouteStageAnalytics({
+      ioObservedDurationMs: input.ioObservedDurationMs,
+      route: "homeworks",
+      stage: input.stage as WorkspaceHomeworksRouteStage | "db_context",
+      status: input.status,
+    });
+    return;
+  }
+
+  writeWorkspaceRouteStageAnalytics({
+    ioObservedDurationMs: input.ioObservedDurationMs,
+    route: "subscriptions_current",
+    stage: input.stage as WorkspaceSubscriptionsCurrentRouteStage | "db_context",
+    status: input.status,
+  });
+}
+
 export function recordWorkspaceRouteDbContext(ioObservedDurationMs: number) {
   const attribution = getWorkspaceRouteAttribution();
   if (!attribution) return;
 
-  writeWorkspaceRouteStageAnalytics({
+  writeWorkspaceRouteStageAnalyticsForRoute({
     ioObservedDurationMs,
     route: attribution.route,
     stage: "db_context",
@@ -159,7 +183,7 @@ export async function runWorkspaceRouteStage<T>(
       work,
     );
     const ioObservedDurationMs = Date.now() - startMs;
-    writeWorkspaceRouteStageAnalytics({
+    writeWorkspaceRouteStageAnalyticsForRoute({
       ioObservedDurationMs,
       route,
       stage,
@@ -175,7 +199,7 @@ export async function runWorkspaceRouteStage<T>(
     return result;
   } catch (error) {
     const ioObservedDurationMs = Date.now() - startMs;
-    writeWorkspaceRouteStageAnalytics({
+    writeWorkspaceRouteStageAnalyticsForRoute({
       ioObservedDurationMs,
       route,
       stage,

--- a/src/lib/log/workspace-route-attribution.ts
+++ b/src/lib/log/workspace-route-attribution.ts
@@ -126,7 +126,9 @@ function writeWorkspaceRouteStageAnalyticsForRoute(input: {
   writeWorkspaceRouteStageAnalytics({
     ioObservedDurationMs: input.ioObservedDurationMs,
     route: "subscriptions_current",
-    stage: input.stage as WorkspaceSubscriptionsCurrentRouteStage | "db_context",
+    stage: input.stage as
+      | WorkspaceSubscriptionsCurrentRouteStage
+      | "db_context",
     status: input.status,
   });
 }

--- a/src/lib/log/workspace-route-attribution.ts
+++ b/src/lib/log/workspace-route-attribution.ts
@@ -4,8 +4,10 @@ import { getApiRequestObservabilityRequestId } from "@/lib/log/api-observability
 import { logAppEvent } from "@/lib/log/app-logger";
 import { isProductionEnvironment } from "@/lib/log/app-logger-core";
 import {
+  type WorkspaceHomeworksRouteStage,
   type WorkspaceRouteName,
   type WorkspaceRouteStage,
+  type WorkspaceSubscriptionsCurrentRouteStage,
   writeWorkspaceRouteStageAnalytics,
 } from "@/lib/metrics/analytics-engine";
 
@@ -124,6 +126,18 @@ export function recordWorkspaceRouteDbContext(ioObservedDurationMs: number) {
   });
 }
 
+export async function runWorkspaceRouteStage<T>(
+  route: "homeworks",
+  stage: WorkspaceHomeworksRouteStage | "db_context",
+  input: { request?: Request },
+  work: () => Promise<T>,
+): Promise<T>;
+export async function runWorkspaceRouteStage<T>(
+  route: "subscriptions_current",
+  stage: WorkspaceSubscriptionsCurrentRouteStage | "db_context",
+  input: { request?: Request },
+  work: () => Promise<T>,
+): Promise<T>;
 export async function runWorkspaceRouteStage<T>(
   route: WorkspaceRouteName,
   stage: WorkspaceRouteStage,

--- a/src/lib/mcp/tools/my-data-homework-tools.ts
+++ b/src/lib/mcp/tools/my-data-homework-tools.ts
@@ -36,7 +36,7 @@ export function registerMyHomeworkTools(server: McpServer) {
         limit,
         semesterId,
       });
-      const homeworkItems = await withHomeworkItemState(homeworks);
+      const homeworkItems = await withHomeworkItemState(homeworks, userId);
 
       return jsonToolResult(
         { homeworks: homeworkItems },

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -190,12 +190,19 @@ type WorkspaceOverviewStageAnalyticsInput = {
   status: "error" | "success";
 };
 
-type WorkspaceRouteStageAnalyticsInput = {
-  ioObservedDurationMs: number;
-  route: WorkspaceRouteName;
-  stage: WorkspaceRouteStage;
-  status: "error" | "success";
-};
+type WorkspaceRouteStageAnalyticsInput =
+  | {
+      ioObservedDurationMs: number;
+      route: "homeworks";
+      stage: WorkspaceHomeworksRouteStage | "db_context";
+      status: "error" | "success";
+    }
+  | {
+      ioObservedDurationMs: number;
+      route: "subscriptions_current";
+      stage: WorkspaceSubscriptionsCurrentRouteStage | "db_context";
+      status: "error" | "success";
+    };
 
 function statusClass(status: number) {
   if (!Number.isFinite(status)) return "unknown";

--- a/tests/integration/comment-rls.test.ts
+++ b/tests/integration/comment-rls.test.ts
@@ -1,0 +1,206 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Prisma } from "@/generated/prisma/client";
+import { prisma, withUserDbContext } from "@/lib/db/prisma";
+
+const rlsTestUserIds = ["rls-test-user-a", "rls-test-user-b"] as const;
+const fixtureIds = {
+  deleted: "rls-test-comment-deleted",
+  loggedIn: "rls-test-comment-logged-in",
+  public: "rls-test-comment-public",
+  softbanned: "rls-test-comment-softbanned",
+} as const;
+
+describe.skipIf(process.env.RLS_TEST_ENABLED !== "true")(
+  "Comment PostgreSQL row security",
+  () => {
+    let firstUserId = "";
+    let secondUserId = "";
+    let adminUserId = "";
+    let sectionId = 0;
+
+    beforeAll(async () => {
+      const users = await prisma.user.findMany({
+        where: { id: { in: [...rlsTestUserIds] } },
+        select: { id: true },
+        orderBy: { id: "asc" },
+      });
+      if (users.length !== 2) throw new Error("Expected two RLS test users");
+      [firstUserId, secondUserId] = [users[0].id, users[1].id];
+      const admin = await prisma.user.findFirst({
+        where: { isAdmin: true },
+        select: { id: true },
+      });
+      if (!admin) throw new Error("Expected a seeded admin user");
+      adminUserId = admin.id;
+      const section = await prisma.section.findFirst({
+        orderBy: { id: "asc" },
+        select: { id: true },
+      });
+      if (!section) throw new Error("Expected a seeded section");
+      sectionId = section.id;
+    });
+
+    afterAll(async () => {
+      await prisma.$disconnect();
+    });
+
+    it("enables forced RLS with collaborative read and moderation policies", async () => {
+      const [table] = await prisma.$queryRaw<
+        { rlsEnabled: boolean; rlsForced: boolean }[]
+      >(Prisma.sql`
+        SELECT relrowsecurity AS "rlsEnabled", relforcerowsecurity AS "rlsForced"
+        FROM pg_class JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+        WHERE pg_namespace.nspname = 'public' AND pg_class.relname = 'Comment'
+      `);
+      const policies = await prisma.$queryRaw<
+        { policyName: string; command: string }[]
+      >(Prisma.sql`
+        SELECT policyname AS "policyName", cmd AS command FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'Comment' ORDER BY policyname
+      `);
+      expect(table).toEqual({ rlsEnabled: true, rlsForced: true });
+      expect(policies).toEqual([
+        { policyName: "Comment_admin_moderator", command: "UPDATE" },
+        { policyName: "Comment_admin_reader", command: "SELECT" },
+        { policyName: "Comment_authenticated_reader", command: "SELECT" },
+        { policyName: "Comment_owner_isolation", command: "ALL" },
+        { policyName: "Comment_public_reader", command: "SELECT" },
+      ]);
+    });
+
+    it("defaults direct reads to public active comments without user context", async () => {
+      const rows = await prisma.comment.findMany({
+        where: { id: { in: Object.values(fixtureIds) } },
+        select: { id: true },
+        orderBy: { id: "asc" },
+      });
+      expect(rows).toEqual([{ id: fixtureIds.public }]);
+    });
+
+    it("isolates authenticated reads across viewers", async () => {
+      const [firstRows, secondRows] = await Promise.all([
+        withUserDbContext(firstUserId, (tx) =>
+          tx.comment.findMany({
+            where: { id: { in: Object.values(fixtureIds) } },
+            select: { id: true, status: true, visibility: true },
+            orderBy: { id: "asc" },
+          }),
+        ),
+        withUserDbContext(secondUserId, (tx) =>
+          tx.comment.findMany({
+            where: { id: { in: Object.values(fixtureIds) } },
+            select: { id: true, status: true, visibility: true },
+            orderBy: { id: "asc" },
+          }),
+        ),
+      ]);
+      expect(firstRows).toEqual([
+        { id: fixtureIds.deleted, status: "deleted", visibility: "public" },
+        {
+          id: fixtureIds.loggedIn,
+          status: "active",
+          visibility: "logged_in_only",
+        },
+        { id: fixtureIds.public, status: "active", visibility: "public" },
+        {
+          id: fixtureIds.softbanned,
+          status: "softbanned",
+          visibility: "public",
+        },
+      ]);
+      expect(secondRows).toEqual([
+        {
+          id: fixtureIds.loggedIn,
+          status: "active",
+          visibility: "logged_in_only",
+        },
+        { id: fixtureIds.public, status: "active", visibility: "public" },
+      ]);
+    });
+
+    it("keeps public read regression for anonymous viewers", async () => {
+      await expect(
+        prisma.comment.findUnique({
+          where: { id: fixtureIds.public },
+          select: { id: true, visibility: true, status: true },
+        }),
+      ).resolves.toEqual({
+        id: fixtureIds.public,
+        status: "active",
+        visibility: "public",
+      });
+      await expect(
+        prisma.comment.findUnique({
+          where: { id: fixtureIds.loggedIn },
+          select: { id: true },
+        }),
+      ).resolves.toBeNull();
+    });
+
+    it("allows admins to read and moderate comments they do not own", async () => {
+      const moderatedId = `rls-test-comment-admin-moderation-${Date.now()}`;
+      await withUserDbContext(firstUserId, (tx) =>
+        tx.comment.create({
+          data: {
+            id: moderatedId,
+            body: "RLS admin moderation fixture",
+            sectionId,
+            status: "active",
+            userId: firstUserId,
+            visibility: "public",
+          },
+        }),
+      );
+      try {
+        await withUserDbContext(adminUserId, (tx) =>
+          tx.comment.update({
+            where: { id: moderatedId },
+            data: {
+              status: "softbanned",
+              moderatedAt: new Date(),
+              moderatedById: adminUserId,
+            },
+          }),
+        );
+        await expect(
+          withUserDbContext(secondUserId, (tx) =>
+            tx.comment.findUnique({
+              where: { id: moderatedId },
+              select: { id: true },
+            }),
+          ),
+        ).resolves.toBeNull();
+        await expect(
+          withUserDbContext(adminUserId, (tx) =>
+            tx.comment.findUnique({
+              where: { id: moderatedId },
+              select: { id: true, status: true },
+            }),
+          ),
+        ).resolves.toEqual({ id: moderatedId, status: "softbanned" });
+      } finally {
+        await withUserDbContext(adminUserId, (tx) =>
+          tx.comment.updateMany({
+            where: { id: moderatedId },
+            data: { status: "deleted", deletedAt: new Date() },
+          }),
+        );
+      }
+    });
+
+    it("rejects forged ownership on writes", async () => {
+      await expect(
+        withUserDbContext(secondUserId, (tx) =>
+          tx.comment.create({
+            data: {
+              body: "forged owner",
+              sectionId,
+              userId: firstUserId,
+              visibility: "public",
+            },
+          }),
+        ),
+      ).rejects.toThrow();
+    });
+  },
+);

--- a/tests/unit/admin-api-service.test.ts
+++ b/tests/unit/admin-api-service.test.ts
@@ -59,6 +59,16 @@ vi.mock("@/lib/db/prisma-errors", () => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   prisma: prismaMock,
+  withUserDbContext: vi.fn((_userId, action) =>
+    action({
+      auditLog: prismaMock.auditLog,
+      comment: prismaMock.comment,
+      description: prismaMock.description,
+      descriptionEdit: prismaMock.descriptionEdit,
+      user: prismaMock.user,
+      userSuspension: prismaMock.userSuspension,
+    }),
+  ),
 }));
 
 describe("admin API 服务", () => {

--- a/tests/unit/admin-moderation-list-pagination.test.ts
+++ b/tests/unit/admin-moderation-list-pagination.test.ts
@@ -7,6 +7,7 @@ const {
   descriptionFindManyMock,
   homeworkCountMock,
   homeworkFindManyMock,
+  withUserDbContextMock,
 } = vi.hoisted(() => ({
   commentCountMock: vi.fn(),
   commentFindManyMock: vi.fn(),
@@ -14,6 +15,7 @@ const {
   descriptionFindManyMock: vi.fn(),
   homeworkCountMock: vi.fn(),
   homeworkFindManyMock: vi.fn(),
+  withUserDbContextMock: vi.fn(),
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
@@ -25,6 +27,7 @@ vi.mock("@/lib/db/prisma", () => ({
     },
     homework: { count: homeworkCountMock, findMany: homeworkFindManyMock },
   },
+  withUserDbContext: withUserDbContextMock,
 }));
 
 import {
@@ -36,6 +39,11 @@ import {
 describe("admin moderation list pagination", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    withUserDbContextMock.mockImplementation((_adminUserId, callback) =>
+      callback({
+        comment: { count: commentCountMock, findMany: commentFindManyMock },
+      }),
+    );
     commentFindManyMock.mockResolvedValue([{ id: "comment-2" }]);
     commentCountMock.mockResolvedValue(5);
     descriptionFindManyMock.mockResolvedValue([{ id: "description-2" }]);
@@ -46,9 +54,18 @@ describe("admin moderation list pagination", () => {
 
   it("applies skip/take and returns a matching total for comments", async () => {
     await expect(
-      listAdminModerationComments({ pageSize: 2, skip: 2, status: "active" }),
+      listAdminModerationComments({
+        adminUserId: "admin-1",
+        pageSize: 2,
+        skip: 2,
+        status: "active",
+      }),
     ).resolves.toEqual({ data: [{ id: "comment-2" }], total: 5 });
 
+    expect(withUserDbContextMock).toHaveBeenCalledWith(
+      "admin-1",
+      expect.any(Function),
+    );
     expect(commentFindManyMock).toHaveBeenCalledWith(
       expect.objectContaining({ skip: 2, take: 2 }),
     );

--- a/tests/unit/analytics-engine-runtime-events.test.ts
+++ b/tests/unit/analytics-engine-runtime-events.test.ts
@@ -97,9 +97,19 @@ describe("Cloudflare Analytics Engine runtime events", () => {
     ] as const;
 
     stages.forEach((entry, index) => {
+      if (entry.route === "homeworks") {
+        writeWorkspaceRouteStageAnalytics({
+          ioObservedDurationMs: index + 10,
+          route: "homeworks",
+          stage: entry.stage,
+          status: "success",
+        });
+        return;
+      }
+
       writeWorkspaceRouteStageAnalytics({
         ioObservedDurationMs: index + 10,
-        route: entry.route,
+        route: "subscriptions_current",
         stage: entry.stage,
         status: "success",
       });

--- a/tests/unit/comment-mutations.test.ts
+++ b/tests/unit/comment-mutations.test.ts
@@ -73,6 +73,13 @@ vi.mock("@/lib/db/prisma", () => ({
   withUserDbContext: withUserDbContextMock,
 }));
 
+vi.mock("@/features/comments/server/comment-db-context", () => ({
+  withCommentDbContext: (
+    _viewerUserId: string | null,
+    action: (client: { comment: typeof prismaMock.comment }) => unknown,
+  ) => action({ comment: prismaMock.comment }),
+}));
+
 vi.mock("@/lib/db/prisma-errors", () => ({
   isPrismaUniqueConstraintError: isPrismaUniqueConstraintErrorMock,
 }));

--- a/tests/unit/comment-read-model-pagination.test.ts
+++ b/tests/unit/comment-read-model-pagination.test.ts
@@ -119,7 +119,13 @@ describe("loadCommentThread pagination", () => {
         : publicReactionSummaryQueryMock(query),
     );
     withUserDbContextMock.mockImplementation((_userId, callback) =>
-      callback({ $queryRaw: contextQueryMock }),
+      callback({
+        $queryRaw: contextQueryMock,
+        comment: {
+          count: commentCountMock,
+          findMany: commentFindManyMock,
+        },
+      }),
     );
   });
 

--- a/tests/unit/comment-read-model-pagination.test.ts
+++ b/tests/unit/comment-read-model-pagination.test.ts
@@ -410,7 +410,9 @@ describe("loadCommentThread pagination", () => {
 
   it("counts anonymous hidden comments across the target without paging them", async () => {
     commentCountMock.mockReset();
-    commentCountMock.mockResolvedValueOnce(1).mockResolvedValueOnce(2);
+    publicQueryMock.mockReset();
+    commentCountMock.mockResolvedValueOnce(1);
+    publicQueryMock.mockResolvedValueOnce([{ count: 2n }]);
     commentFindManyMock.mockResolvedValueOnce([]);
 
     const result = await loadCommentThread({
@@ -426,14 +428,7 @@ describe("loadCommentThread pagination", () => {
     });
 
     expect(result).toMatchObject({ comments: [], hiddenCount: 2, total: 1 });
-    expect(commentCountMock).toHaveBeenNthCalledWith(2, {
-      where: {
-        AND: [
-          { teacherId: 5 },
-          { visibility: "logged_in_only" },
-          { status: { not: "deleted" } },
-        ],
-      },
-    });
+    expect(commentCountMock).toHaveBeenCalledTimes(1);
+    expect(publicQueryMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/comment-read-model-pagination.test.ts
+++ b/tests/unit/comment-read-model-pagination.test.ts
@@ -99,6 +99,21 @@ function target(whereTarget: Record<string, number | string>) {
   } satisfies Parameters<typeof loadCommentThread>[0]["target"];
 }
 
+function rawQuerySql(query: unknown): string {
+  if (Array.isArray(query)) {
+    return query.join("");
+  }
+  if (
+    query &&
+    typeof query === "object" &&
+    "strings" in query &&
+    Array.isArray((query as { strings: string[] }).strings)
+  ) {
+    return (query as { strings: string[] }).strings.join(" ");
+  }
+  return "";
+}
+
 describe("loadCommentThread pagination", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -110,12 +125,12 @@ describe("loadCommentThread pagination", () => {
     reactionSummaryQueryMock.mockResolvedValue([]);
     attachmentSummaryQueryMock.mockResolvedValue([]);
     contextQueryMock.mockImplementation((query) =>
-      query.strings.join(" ").includes("comment_attachment_summaries")
+      rawQuerySql(query).includes("comment_attachment_summaries")
         ? attachmentSummaryQueryMock(query)
         : reactionSummaryQueryMock(query),
     );
     publicQueryMock.mockImplementation((query) => {
-      const sql = query?.strings?.join?.(" ") ?? "";
+      const sql = rawQuerySql(query);
       if (sql.includes("comment_hidden_root_count")) {
         return Promise.resolve([{ count: 0n }]);
       }

--- a/tests/unit/comment-read-model-pagination.test.ts
+++ b/tests/unit/comment-read-model-pagination.test.ts
@@ -102,8 +102,9 @@ function target(whereTarget: Record<string, number | string>) {
 describe("loadCommentThread pagination", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    accountFindManyMock.mockResolvedValue([]);
+    commentCountMock.mockReset();
     commentCountMock.mockResolvedValue(3);
+    accountFindManyMock.mockResolvedValue([]);
     publicReactionSummaryQueryMock.mockResolvedValue([]);
     publicAttachmentSummaryQueryMock.mockResolvedValue([]);
     reactionSummaryQueryMock.mockResolvedValue([]);
@@ -113,11 +114,16 @@ describe("loadCommentThread pagination", () => {
         ? attachmentSummaryQueryMock(query)
         : reactionSummaryQueryMock(query),
     );
-    publicQueryMock.mockImplementation((query) =>
-      query.strings.join(" ").includes("comment_attachment_summaries")
-        ? publicAttachmentSummaryQueryMock(query)
-        : publicReactionSummaryQueryMock(query),
-    );
+    publicQueryMock.mockImplementation((query) => {
+      const sql = query?.strings?.join?.(" ") ?? "";
+      if (sql.includes("comment_hidden_root_count")) {
+        return Promise.resolve([{ count: 0n }]);
+      }
+      if (sql.includes("comment_attachment_summaries")) {
+        return publicAttachmentSummaryQueryMock(query);
+      }
+      return publicReactionSummaryQueryMock(query);
+    });
     withUserDbContextMock.mockImplementation((_userId, callback) =>
       callback({
         $queryRaw: contextQueryMock,

--- a/tests/unit/compact-overview-read-model.test.ts
+++ b/tests/unit/compact-overview-read-model.test.ts
@@ -267,7 +267,7 @@ describe("compact workspace overview read model", () => {
     expect(listSubscribedSchedulesMock).not.toHaveBeenCalled();
     expect(listSubscribedHomeworksMock).not.toHaveBeenCalled();
     expect(listUpcomingSubscribedExamsMock).not.toHaveBeenCalled();
-    expect(withHomeworkItemStateMock).toHaveBeenCalledWith([]);
+    expect(withHomeworkItemStateMock).toHaveBeenCalledWith([], "user-1");
     expect(overview.user).toEqual(expectedUser);
     expect(overview.counts).toEqual({
       dueSoonHomeworks: 0,

--- a/tests/unit/workspace-route-attribution.test.ts
+++ b/tests/unit/workspace-route-attribution.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setApiRequestObservabilityContext } from "@/lib/log/api-observability";
 
 const {
@@ -40,6 +40,7 @@ describe("workspace route attribution", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });


### PR DESCRIPTION
## Summary
- Enable `FORCE ROW LEVEL SECURITY` on `Comment` with public, authenticated, owner, and admin moderation policies matching the app-layer visibility matrix.
- Route comment reads/writes and admin moderation queries through `withUserDbContext` / `withCommentDbContext`.
- Add `tests/integration/comment-rls.test.ts` for cross-user isolation, anonymous public-read regression, admin moderation, and forged-owner write rejection.

Closes #601 (first collaborative-content slice: Comment table).

## Policies added
| Policy | Command | Purpose |
|--------|---------|---------|
| `Comment_public_reader` | SELECT | Anonymous read of active `public` comments |
| `Comment_authenticated_reader` | SELECT | Signed-in read of active comments + own softbanned |
| `Comment_admin_reader` | SELECT | Admin read of active/softbanned/deleted moderation queue |
| `Comment_owner_isolation` | ALL | Author create/read/update/delete on own rows |
| `Comment_admin_moderator` | UPDATE | Admin moderation updates |

## Test coverage
- Integration (`comment-rls.test.ts`): policy contract, default-deny without context, cross-user isolation, public-read regression, admin moderation path, forged-owner write rejection
- Unit: comment read-model pagination context, comment mutations context, admin moderation list + moderateComment context, homework item state viewer context

## Test plan
- [x] `bunx vitest run` (unit)
- [ ] `ci:rls` integration job (`comment-rls.test.ts` with `life_ustc_runtime`)
- [x] `biome check` on touched files

<!-- project-relationship:start -->
## Project relationship

Part of #601.
<!-- project-relationship:end -->