### PR TITLE
perf(catalog): extend client-tab shell to course and teacher detail

### DIFF
--- a/src/features/admin/lib/moderation-target-display.ts
+++ b/src/features/admin/lib/moderation-target-display.ts
@@ -4,6 +4,10 @@ import type {
   ModerationDescriptionLike,
 } from "@/features/admin/lib/moderation-display-types";
 import {
+  courseDetailPagePath,
+  teacherDetailPagePath,
+} from "@/features/catalog/lib/catalog-detail-tab";
+import {
   commentPermalinkHref,
   commentTargetPermalinkBaseHref,
 } from "@/features/comments/lib/comment-panel-links";
@@ -115,9 +119,9 @@ export function moderationDescriptionTargetHref(
   if (description.section?.jwId)
     return sectionDetailPagePath(description.section.jwId, "introduction");
   if (description.course?.jwId)
-    return `/catalog/courses/${description.course.jwId}/introduction`;
+    return courseDetailPagePath(description.course.jwId, "introduction");
   if (description.teacher?.id)
-    return `/catalog/teachers/${description.teacher.id}/introduction`;
+    return teacherDetailPagePath(description.teacher.id, "introduction");
   if (description.homework?.id) return "/admin/moderation?tab=homeworks";
   return "/admin/moderation?tab=descriptions";
 }

--- a/src/features/catalog/lib/catalog-detail-tab-client.ts
+++ b/src/features/catalog/lib/catalog-detail-tab-client.ts
@@ -1,0 +1,145 @@
+import type {
+  CourseDetailSection,
+  TeacherDetailSection,
+} from "@/features/catalog/components/catalog-detail-component-types";
+import type { DescriptionPayload } from "@/features/descriptions/lib/description-card-actions";
+import { fetchDescriptionPayload } from "@/features/descriptions/lib/description-card-client";
+import type { DescriptionViewer } from "@/features/descriptions/lib/description-payload-types";
+import { emptyDescriptionPayload } from "@/features/descriptions/server/description-payload";
+import type { AppLocale } from "@/i18n/config";
+import { apiClient } from "@/lib/api/client";
+import type { CatalogDetailTab } from "./catalog-detail-tab";
+
+type CatalogDetailKind = "course" | "teacher";
+
+type CatalogDetailTabPanelState = {
+  descriptionData: DescriptionPayload;
+  sections: CourseDetailSection[] | TeacherDetailSection[];
+};
+
+type CatalogDetailTabPanelPatch = Partial<CatalogDetailTabPanelState>;
+
+function emptyDescriptionViewer(userId: string | null): DescriptionViewer {
+  return {
+    image: null,
+    isAdmin: false,
+    isAuthenticated: Boolean(userId),
+    isSuspended: false,
+    name: null,
+    suspensionExpiresAt: null,
+    suspensionReason: null,
+    userId,
+  };
+}
+
+function emptyPanelState(userId: string | null): CatalogDetailTabPanelState {
+  return {
+    descriptionData: emptyDescriptionPayload(emptyDescriptionViewer(userId)),
+    sections: [],
+  };
+}
+
+function applyPanelPatch(
+  state: CatalogDetailTabPanelState,
+  patch: CatalogDetailTabPanelPatch,
+): CatalogDetailTabPanelState {
+  return { ...state, ...patch };
+}
+
+async function loadIntroductionPanel(
+  targetType: CatalogDetailKind,
+  targetId: number,
+): Promise<CatalogDetailTabPanelPatch> {
+  const result = await fetchDescriptionPayload({
+    targetId,
+    targetType,
+  });
+  if (result.ok && result.payload) {
+    return { descriptionData: result.payload };
+  }
+  return {};
+}
+
+async function loadCourseSectionsPanel(
+  jwId: number,
+  locale: AppLocale,
+): Promise<CatalogDetailTabPanelPatch> {
+  const result = await apiClient.GET<{ sections?: CourseDetailSection[] }>(
+    `/api/catalog/courses/${jwId}`,
+    {
+      params: { query: { locale } },
+    },
+  );
+  if (!result.response.ok || !result.data) {
+    throw new Error("Failed to load course sections");
+  }
+  return { sections: result.data.sections ?? [] };
+}
+
+async function loadTeacherSectionsPanel(
+  id: number,
+  locale: AppLocale,
+): Promise<CatalogDetailTabPanelPatch> {
+  const result = await apiClient.GET<{ sections?: TeacherDetailSection[] }>(
+    `/api/catalog/teachers/${id}`,
+    {
+      params: { query: { locale } },
+    },
+  );
+  if (!result.response.ok || !result.data) {
+    throw new Error("Failed to load teacher sections");
+  }
+  return { sections: result.data.sections ?? [] };
+}
+
+const tabLoaders: Record<
+  Exclude<CatalogDetailTab, "overview" | "comments">,
+  (input: {
+    id: number;
+    jwId: number;
+    kind: CatalogDetailKind;
+    locale: AppLocale;
+  }) => Promise<CatalogDetailTabPanelPatch>
+> = {
+  introduction: ({ id, kind }) => loadIntroductionPanel(kind, id),
+  sections: ({ id, jwId, kind, locale }) =>
+    kind === "course"
+      ? loadCourseSectionsPanel(jwId, locale)
+      : loadTeacherSectionsPanel(id, locale),
+};
+
+export function createCatalogDetailTabPanelStore(
+  kind: CatalogDetailKind,
+  userId: string | null,
+) {
+  const loaded = new Set<CatalogDetailTab>();
+  let state = emptyPanelState(userId);
+
+  return {
+    getState: () => state,
+    isLoaded: (tab: CatalogDetailTab) => loaded.has(tab),
+    async ensureLoaded(
+      tab: CatalogDetailTab,
+      input: {
+        id: number;
+        jwId: number;
+        locale: AppLocale;
+      },
+    ) {
+      if (tab === "overview" || tab === "comments" || loaded.has(tab)) {
+        loaded.add(tab);
+        return state;
+      }
+
+      const loader = tabLoaders[tab];
+      const patch = await loader({ ...input, kind });
+      state = applyPanelPatch(state, patch);
+      loaded.add(tab);
+      return state;
+    },
+    reset() {
+      loaded.clear();
+      state = emptyPanelState(userId);
+    },
+  };
+}

--- a/src/features/catalog/lib/catalog-detail-tab.ts
+++ b/src/features/catalog/lib/catalog-detail-tab.ts
@@ -1,0 +1,67 @@
+export const CATALOG_DETAIL_TAB_QUERY = "tab";
+
+export const catalogDetailTabs = [
+  "overview",
+  "introduction",
+  "sections",
+  "comments",
+] as const;
+
+export type CatalogDetailTab = (typeof catalogDetailTabs)[number];
+
+const catalogDetailTabSet = new Set<string>(catalogDetailTabs);
+
+const catalogDetailLegacyPathTab = /^(introduction|sections|comments)$/;
+
+export function isCatalogDetailTab(
+  value: string | null | undefined,
+): value is CatalogDetailTab {
+  return value != null && catalogDetailTabSet.has(value);
+}
+
+export function parseCatalogDetailTab(
+  value: string | null | undefined,
+): CatalogDetailTab {
+  return isCatalogDetailTab(value) ? value : "overview";
+}
+
+export function catalogDetailTabSearch(tab: CatalogDetailTab) {
+  return tab === "overview" ? "" : `?${CATALOG_DETAIL_TAB_QUERY}=${tab}`;
+}
+
+export function courseDetailPagePath(
+  jwId: number | string,
+  tab: CatalogDetailTab = "overview",
+) {
+  return `/catalog/courses/${jwId}${catalogDetailTabSearch(tab)}`;
+}
+
+export function teacherDetailPagePath(
+  id: number | string,
+  tab: CatalogDetailTab = "overview",
+) {
+  return `/catalog/teachers/${id}${catalogDetailTabSearch(tab)}`;
+}
+
+export function resolveCatalogDetailTabRedirect(
+  request: Request,
+  kind: "courses" | "teachers",
+) {
+  if (request.method !== "GET" && request.method !== "HEAD") return null;
+
+  const url = new URL(request.url);
+  const match = new RegExp(`^/catalog/${kind}/([1-9]\\d*)/([^/]+)/?$`).exec(
+    url.pathname,
+  );
+  if (!match) return null;
+
+  const [, identifier, segment] = match;
+  if (!catalogDetailLegacyPathTab.test(segment)) return null;
+
+  const redirectUrl = new URL(`/catalog/${kind}/${identifier}`, url.origin);
+  for (const [key, value] of url.searchParams) {
+    redirectUrl.searchParams.append(key, value);
+  }
+  redirectUrl.searchParams.set(CATALOG_DETAIL_TAB_QUERY, segment);
+  return `${redirectUrl.pathname}${redirectUrl.search}`;
+}

--- a/src/features/catalog/lib/catalog-detail-tab.ts
+++ b/src/features/catalog/lib/catalog-detail-tab.ts
@@ -13,6 +13,10 @@ const catalogDetailTabSet = new Set<string>(catalogDetailTabs);
 
 const catalogDetailLegacyPathTab = /^(introduction|sections|comments)$/;
 
+export function isCatalogDetailLegacyPathTab(segment: string): boolean {
+  return catalogDetailLegacyPathTab.test(segment);
+}
+
 export function isCatalogDetailTab(
   value: string | null | undefined,
 ): value is CatalogDetailTab {
@@ -56,7 +60,7 @@ export function resolveCatalogDetailTabRedirect(
   if (!match) return null;
 
   const [, identifier, segment] = match;
-  if (!catalogDetailLegacyPathTab.test(segment)) return null;
+  if (!isCatalogDetailLegacyPathTab(segment)) return null;
 
   const redirectUrl = new URL(`/catalog/${kind}/${identifier}`, url.origin);
   for (const [key, value] of url.searchParams) {

--- a/src/features/catalog/server/catalog-detail-page-server.ts
+++ b/src/features/catalog/server/catalog-detail-page-server.ts
@@ -1,4 +1,8 @@
 import { error, redirect } from "@sveltejs/kit";
+import {
+  type CatalogDetailTab,
+  parseCatalogDetailTab,
+} from "@/features/catalog/lib/catalog-detail-tab";
 import { catalogPrimaryName } from "@/features/catalog/lib/catalog-list-display";
 import {
   buildCourseStructuredData,
@@ -26,23 +30,15 @@ import {
   getTeacherDetailCopy,
 } from "./catalog-detail-copy";
 
-export type CourseDetailRouteSection =
-  | "overview"
-  | "introduction"
-  | "sections"
-  | "comments";
+export type CourseDetailRouteSection = CatalogDetailTab;
+export type TeacherDetailRouteSection = CatalogDetailTab;
 
-export type TeacherDetailRouteSection =
-  | "overview"
-  | "introduction"
-  | "sections"
-  | "comments";
-
-const catalogDetailRouteSections = new Set([
-  "introduction",
-  "sections",
-  "comments",
-]);
+function resolveCatalogDetailInitialTab(
+  section: string | undefined,
+  url: URL,
+): CatalogDetailTab {
+  return parseCatalogDetailTab(section ?? url.searchParams.get("tab"));
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object";
@@ -72,15 +68,6 @@ function isPublicTeacherCore(value: unknown, id: number) {
   );
 }
 
-function resolveCatalogDetailRouteSection(
-  section: string | undefined,
-): CourseDetailRouteSection | null {
-  if (!section) return "overview";
-  return catalogDetailRouteSections.has(section)
-    ? (section as CourseDetailRouteSection)
-    : null;
-}
-
 export async function loadCourseDetailPage({
   locals,
   params,
@@ -92,11 +79,10 @@ export async function loadCourseDetailPage({
   url: URL;
 }) {
   const copy = getCourseDetailCopy(locals.locale);
-  const detailSection = resolveCatalogDetailRouteSection(params.section);
-  if (!detailSection) error(404, copy.notFound.description);
+  const initialTab = resolveCatalogDetailInitialTab(params.section, url);
   const jwId = Number(params.jwId);
   if (!Number.isInteger(jwId)) error(404, copy.notFound.description);
-  const includeSections = detailSection === "sections";
+  const includeSections = initialTab === "sections";
   const loadCourse = () =>
     getCoursePage(jwId, locals.locale, { includeSections });
   const courseCacheOptions =
@@ -130,17 +116,23 @@ export async function loadCourseDetailPage({
   ]);
   if (!course) error(404, copy.notFound.description);
   if (course.jwId !== jwId) {
-    const sectionPath = detailSection === "overview" ? "" : `/${detailSection}`;
-    redirect(308, `/catalog/courses/${course.jwId}${sectionPath}${url.search}`);
+    const redirectUrl = new URL(`/catalog/courses/${course.jwId}`, url.origin);
+    for (const [key, value] of url.searchParams) {
+      redirectUrl.searchParams.append(key, value);
+    }
+    if (initialTab !== "overview") {
+      redirectUrl.searchParams.set("tab", initialTab);
+    }
+    redirect(308, `${redirectUrl.pathname}${redirectUrl.search}`);
   }
   const displayName = catalogPrimaryName(course) || course.code;
   const includeDescription =
-    detailSection === "introduction" || detailSection === "overview";
+    initialTab === "introduction" || initialTab === "overview";
   const { commentsData, descriptionData } = await loadCatalogDetailCommentsData(
     {
-      includeComments: detailSection === "comments",
+      includeComments: false,
       includeDescription,
-      includeDescriptionHistory: detailSection === "introduction",
+      includeDescriptionHistory: initialTab === "introduction",
       targetId: course.id,
       type: "course",
       viewer,
@@ -170,7 +162,7 @@ export async function loadCourseDetailPage({
     copy,
     descriptionData,
     commentsData,
-    detailSection,
+    detailSection: initialTab,
     socialMetadata,
     structuredDataJson: serializeStructuredData(
       buildCourseStructuredData({
@@ -198,11 +190,10 @@ export async function loadTeacherDetailPage({
   url: URL;
 }) {
   const copy = getTeacherDetailCopy(locals.locale);
-  const detailSection = resolveCatalogDetailRouteSection(params.section);
-  if (!detailSection) error(404, copy.notFound.description);
+  const initialTab = resolveCatalogDetailInitialTab(params.section, url);
   const id = Number(params.id);
   if (!Number.isInteger(id)) error(404, copy.notFound.description);
-  const includeSections = detailSection === "sections";
+  const includeSections = initialTab === "sections";
   const loadTeacher = () =>
     getTeacherPage(id, locals.locale, { includeSections });
   const teacherCacheOptions =
@@ -237,12 +228,12 @@ export async function loadTeacherDetailPage({
   if (!teacher) error(404, copy.notFound.description);
   const displayName = catalogPrimaryName(teacher);
   const includeDescription =
-    detailSection === "introduction" || detailSection === "overview";
+    initialTab === "introduction" || initialTab === "overview";
   const { commentsData, descriptionData } = await loadCatalogDetailCommentsData(
     {
-      includeComments: detailSection === "comments",
+      includeComments: false,
       includeDescription,
-      includeDescriptionHistory: detailSection === "introduction",
+      includeDescriptionHistory: initialTab === "introduction",
       targetId: teacher.id,
       type: "teacher",
       viewer,
@@ -277,7 +268,7 @@ export async function loadTeacherDetailPage({
     copy,
     descriptionData,
     commentsData,
-    detailSection,
+    detailSection: initialTab,
     socialMetadata,
     structuredDataJson: serializeStructuredData(
       buildTeacherStructuredData({

--- a/src/features/comments/lib/comment-panel-links.ts
+++ b/src/features/comments/lib/comment-panel-links.ts
@@ -1,4 +1,8 @@
 import {
+  courseDetailPagePath,
+  teacherDetailPagePath,
+} from "@/features/catalog/lib/catalog-detail-tab";
+import {
   sectionDetailHomeworkPath,
   sectionDetailPagePath,
 } from "@/features/section-detail/lib/section-detail-tab";
@@ -63,16 +67,12 @@ export type CommentPermalinkTarget =
       type: "homework";
     };
 
-function pathSegment(value: PermalinkPathValue) {
-  return encodeURIComponent(String(value));
-}
-
 export function commentTargetPermalinkBaseHref(target: CommentPermalinkTarget) {
   if (target.type === "course") {
-    return `/catalog/courses/${pathSegment(target.courseJwId)}/comments`;
+    return courseDetailPagePath(target.courseJwId, "comments");
   }
   if (target.type === "teacher") {
-    return `/catalog/teachers/${pathSegment(target.teacherId)}/comments`;
+    return teacherDetailPagePath(target.teacherId, "comments");
   }
   if (target.type === "homework") {
     return sectionDetailHomeworkPath(target.sectionJwId, {

--- a/src/lib/cloudflare/public-ssr-gateway.ts
+++ b/src/lib/cloudflare/public-ssr-gateway.ts
@@ -1,3 +1,4 @@
+import { resolveCatalogDetailTabRedirect } from "@/features/catalog/lib/catalog-detail-tab";
 import { hasRequestAuthSignal } from "@/lib/auth/request-auth-signal";
 
 export const PUBLIC_SSR_HEADER = "x-life-public-ssr";
@@ -37,18 +38,6 @@ const DIRECT_REQUEST_PATHS = new Set([
 
 const CATALOG_DETAIL_PATH =
   /^\/catalog\/(courses|sections|teachers)\/([1-9]\d*)(?:\/([^/]+))?$/;
-const CATALOG_DETAIL_SECTIONS: Record<string, ReadonlySet<string>> = {
-  courses: new Set(["introduction", "sections", "comments"]),
-  sections: new Set([
-    "introduction",
-    "calendar",
-    "exams",
-    "homework",
-    "teachers",
-    "comments",
-  ]),
-  teachers: new Set(["introduction", "sections", "comments"]),
-};
 const SECTION_DETAIL_LEGACY_TAB_PATH =
   /^\/catalog\/sections\/([1-9]\d*)\/(introduction|calendar|exams|homework|teachers|comments)\/?$/;
 
@@ -90,6 +79,14 @@ export function resolveSectionDetailTabRedirect(request: Request) {
   return `${redirectUrl.pathname}${redirectUrl.search}`;
 }
 
+export function resolveCourseDetailTabRedirect(request: Request) {
+  return resolveCatalogDetailTabRedirect(request, "courses");
+}
+
+export function resolveTeacherDetailTabRedirect(request: Request) {
+  return resolveCatalogDetailTabRedirect(request, "teachers");
+}
+
 function matchesPathRoot(pathname: string, root: string) {
   return pathname === root || pathname.startsWith(`${root}/`);
 }
@@ -107,11 +104,10 @@ function acceptsHtml(request: Request) {
 function isCanonicalCatalogDetailPath(pathname: string) {
   const match = CATALOG_DETAIL_PATH.exec(pathname);
   if (!match) return false;
-  const [, collection, identifier, section] = match;
+  const [, , identifier, section] = match;
   const id = Number(identifier);
   if (!Number.isSafeInteger(id)) return false;
-  if (collection === "sections") return !section;
-  return !section || CATALOG_DETAIL_SECTIONS[collection]?.has(section) === true;
+  return !section;
 }
 
 export function resolvePublicSsrMode(

--- a/src/routes/catalog/courses/[jwId]/[section]/+page.server.ts
+++ b/src/routes/catalog/courses/[jwId]/[section]/+page.server.ts
@@ -1,8 +1,15 @@
-import { redirect } from "@sveltejs/kit";
-import { CATALOG_DETAIL_TAB_QUERY } from "@/features/catalog/lib/catalog-detail-tab";
+import { error, redirect } from "@sveltejs/kit";
+import {
+  CATALOG_DETAIL_TAB_QUERY,
+  isCatalogDetailLegacyPathTab,
+} from "@/features/catalog/lib/catalog-detail-tab";
 import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = ({ params, url }) => {
+  if (!isCatalogDetailLegacyPathTab(params.section)) {
+    error(404);
+  }
+
   const redirectUrl = new URL(`/catalog/courses/${params.jwId}`, url);
   for (const [key, value] of url.searchParams) {
     redirectUrl.searchParams.append(key, value);

--- a/src/routes/catalog/courses/[jwId]/[section]/+page.server.ts
+++ b/src/routes/catalog/courses/[jwId]/[section]/+page.server.ts
@@ -1,4 +1,14 @@
-import { loadCourseDetailPage } from "@/features/catalog/server/catalog-detail-page-server";
-import type { PageServerLoad } from "./$types";
+import { redirect } from "@sveltejs/kit";
+import { CATALOG_DETAIL_TAB_QUERY } from "@/features/catalog/lib/catalog-detail-tab";
+import type { Actions, PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = loadCourseDetailPage;
+export const load: PageServerLoad = ({ params, url }) => {
+  const redirectUrl = new URL(`/catalog/courses/${params.jwId}`, url);
+  for (const [key, value] of url.searchParams) {
+    redirectUrl.searchParams.append(key, value);
+  }
+  redirectUrl.searchParams.set(CATALOG_DETAIL_TAB_QUERY, params.section);
+  redirect(308, `${redirectUrl.pathname}${redirectUrl.search}`);
+};
+
+export const actions = {} satisfies Actions;

--- a/src/routes/catalog/teachers/[id]/[section]/+page.server.ts
+++ b/src/routes/catalog/teachers/[id]/[section]/+page.server.ts
@@ -1,8 +1,15 @@
-import { redirect } from "@sveltejs/kit";
-import { CATALOG_DETAIL_TAB_QUERY } from "@/features/catalog/lib/catalog-detail-tab";
+import { error, redirect } from "@sveltejs/kit";
+import {
+  CATALOG_DETAIL_TAB_QUERY,
+  isCatalogDetailLegacyPathTab,
+} from "@/features/catalog/lib/catalog-detail-tab";
 import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = ({ params, url }) => {
+  if (!isCatalogDetailLegacyPathTab(params.section)) {
+    error(404);
+  }
+
   const redirectUrl = new URL(`/catalog/teachers/${params.id}`, url);
   for (const [key, value] of url.searchParams) {
     redirectUrl.searchParams.append(key, value);

--- a/src/routes/catalog/teachers/[id]/[section]/+page.server.ts
+++ b/src/routes/catalog/teachers/[id]/[section]/+page.server.ts
@@ -1,4 +1,12 @@
-import { loadTeacherDetailPage } from "@/features/catalog/server/catalog-detail-page-server";
+import { redirect } from "@sveltejs/kit";
+import { CATALOG_DETAIL_TAB_QUERY } from "@/features/catalog/lib/catalog-detail-tab";
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = loadTeacherDetailPage;
+export const load: PageServerLoad = ({ params, url }) => {
+  const redirectUrl = new URL(`/catalog/teachers/${params.id}`, url);
+  for (const [key, value] of url.searchParams) {
+    redirectUrl.searchParams.append(key, value);
+  }
+  redirectUrl.searchParams.set(CATALOG_DETAIL_TAB_QUERY, params.section);
+  redirect(308, `${redirectUrl.pathname}${redirectUrl.search}`);
+};

--- a/src/worker.js
+++ b/src/worker.js
@@ -17,10 +17,12 @@ import {
   PUBLIC_SSR_NONCE_PLACEHOLDER,
   PUBLIC_SSR_PAGE_EDGE_CACHE_CONTROL,
   removePublicSsrHeaders,
+  resolveCourseDetailTabRedirect,
   resolveLegacyCatalogRedirect,
   resolvePublicSsrLocale,
   resolvePublicSsrMode,
   resolveSectionDetailTabRedirect,
+  resolveTeacherDetailTabRedirect,
 } from "./lib/cloudflare/public-ssr-gateway";
 import { buildContentSecurityPolicy } from "./lib/security/csp";
 import { CONTENT_SIGNAL } from "./lib/seo/content-signal";
@@ -202,6 +204,26 @@ export default {
         headers: {
           "Cache-Control": "public, max-age=86400",
           Location: sectionTabRedirect,
+        },
+      });
+    }
+    const courseTabRedirect = resolveCourseDetailTabRedirect(request);
+    if (courseTabRedirect) {
+      return new Response(null, {
+        status: 308,
+        headers: {
+          "Cache-Control": "public, max-age=86400",
+          Location: courseTabRedirect,
+        },
+      });
+    }
+    const teacherTabRedirect = resolveTeacherDetailTabRedirect(request);
+    if (teacherTabRedirect) {
+      return new Response(null, {
+        status: 308,
+        headers: {
+          "Cache-Control": "public, max-age=86400",
+          Location: teacherTabRedirect,
         },
       });
     }

--- a/tests/e2e/src/app/courses/[jwId]/test.ts
+++ b/tests/e2e/src/app/courses/[jwId]/test.ts
@@ -85,7 +85,7 @@ test.describe("/catalog/courses/[jwId] 课程详情", () => {
       `/catalog/courses/${DEV_SEED.course.legacyJwId}/sections?from=legacy`,
     );
     await expect(page).toHaveURL(
-      `/catalog/courses/${DEV_SEED.course.jwId}/sections?from=legacy`,
+      `/catalog/courses/${DEV_SEED.course.jwId}?from=legacy&tab=sections`,
     );
     await expect(page.getByRole("heading", { level: 1 }).first()).toContainText(
       new RegExp(`${DEV_SEED.course.nameCn}|${DEV_SEED.course.nameEn}`),
@@ -221,7 +221,7 @@ test.describe("/catalog/courses/[jwId] 课程详情", () => {
     ).toBeVisible();
 
     await jumpToCourseSection(page, /评论|Comments/i, "#course-comments");
-    await expect(page).toHaveURL(/\/catalog\/courses\/\d+\/comments$/);
+    await expect(page).toHaveURL(/\/catalog\/courses\/\d+\?tab=comments$/);
     await captureStepScreenshot(page, testInfo, "course/detail-nav");
   });
 
@@ -288,7 +288,7 @@ test.describe("/catalog/courses/[jwId] 课程详情", () => {
 
   test("登录用户可以编辑课程简介", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
-    await signInAsDebugUser(page, `${COURSE_URL}/introduction`);
+    await signInAsDebugUser(page, `${COURSE_URL}?tab=introduction`);
     const snapshot = await snapshotDescriptionTargetForE2e(
       page.request,
       { courseJwId: DEV_SEED.course.jwId, targetType: "course" },
@@ -350,7 +350,7 @@ test.describe("/catalog/courses/[jwId] 课程详情", () => {
 
     try {
       await jumpToCourseSection(page, /评论|Comments/i, "#course-comments");
-      await expect(page).toHaveURL(/\/catalog\/courses\/\d+\/comments$/);
+      await expect(page).toHaveURL(/\/catalog\/courses\/\d+\?tab=comments$/);
 
       const body = `e2e-course-comment-${Date.now()}`;
       const composer = page.locator("#course-comments textarea").first();

--- a/tests/e2e/src/app/teachers/[id]/test.ts
+++ b/tests/e2e/src/app/teachers/[id]/test.ts
@@ -213,7 +213,7 @@ test.describe("/catalog/teachers/[id] 教师详情页", () => {
     ).toBeVisible();
 
     await jumpToTeacherSection(page, /评论|Comments/i, "#teacher-comments");
-    await expect(page).toHaveURL(/\/catalog\/teachers\/\d+\/comments$/);
+    await expect(page).toHaveURL(/\/catalog\/teachers\/\d+\?tab=comments$/);
     await captureStepScreenshot(page, testInfo, "teacher/detail-nav");
   });
 
@@ -323,7 +323,7 @@ test.describe("/catalog/teachers/[id] 教师详情页", () => {
           await navigateToSeedTeacher(page);
         }
         await jumpToTeacherSection(page, /评论|Comments/i, "#teacher-comments");
-        await expect(page).toHaveURL(/\/catalog\/teachers\/\d+\/comments$/);
+        await expect(page).toHaveURL(/\/catalog\/teachers\/\d+\?tab=comments$/);
       }).toPass({
         timeout: 10_000,
         intervals: [250, 500, 1_000],

--- a/tests/unit/catalog-detail-tab.test.ts
+++ b/tests/unit/catalog-detail-tab.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+import {
+  courseDetailPagePath,
+  parseCatalogDetailTab,
+  resolveCatalogDetailTabRedirect,
+  teacherDetailPagePath,
+} from "@/features/catalog/lib/catalog-detail-tab";
+
+function request(path: string) {
+  return new Request(`https://life-ustc.test${path}`, {
+    headers: { accept: "text/html" },
+  });
+}
+
+describe("catalog detail tab helpers", () => {
+  test.each([
+    [undefined, "overview"],
+    [null, "overview"],
+    ["introduction", "introduction"],
+    ["sections", "sections"],
+    ["comments", "comments"],
+    ["invalid", "overview"],
+  ] as const)("parseCatalogDetailTab(%s) -> %s", (value, expected) => {
+    expect(parseCatalogDetailTab(value)).toBe(expected);
+  });
+
+  test.each([
+    [123, "overview", "/catalog/courses/123"],
+    [123, "introduction", "/catalog/courses/123?tab=introduction"],
+    [456, "comments", "/catalog/courses/456?tab=comments"],
+  ] as const)("courseDetailPagePath(%s, %s) -> %s", (jwId, tab, expected) => {
+    expect(courseDetailPagePath(jwId, tab)).toBe(expected);
+  });
+
+  test.each([
+    [42, "overview", "/catalog/teachers/42"],
+    [42, "sections", "/catalog/teachers/42?tab=sections"],
+  ] as const)("teacherDetailPagePath(%s, %s) -> %s", (id, tab, expected) => {
+    expect(teacherDetailPagePath(id, tab)).toBe(expected);
+  });
+
+  test("redirects legacy course tab paths to shell query tabs", () => {
+    expect(
+      resolveCatalogDetailTabRedirect(
+        request("/catalog/courses/123/introduction?foo=bar"),
+        "courses",
+      ),
+    ).toBe("/catalog/courses/123?foo=bar&tab=introduction");
+  });
+
+  test("redirects legacy teacher tab paths to shell query tabs", () => {
+    expect(
+      resolveCatalogDetailTabRedirect(
+        request("/catalog/teachers/9/comments"),
+        "teachers",
+      ),
+    ).toBe("/catalog/teachers/9?tab=comments");
+  });
+
+  test("ignores unknown legacy segments", () => {
+    expect(
+      resolveCatalogDetailTabRedirect(
+        request("/catalog/courses/123/overview"),
+        "courses",
+      ),
+    ).toBeNull();
+  });
+});

--- a/tests/unit/catalog-detail-tab.test.ts
+++ b/tests/unit/catalog-detail-tab.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   courseDetailPagePath,
+  isCatalogDetailLegacyPathTab,
   parseCatalogDetailTab,
   resolveCatalogDetailTabRedirect,
   teacherDetailPagePath,
@@ -64,5 +65,8 @@ describe("catalog detail tab helpers", () => {
         "courses",
       ),
     ).toBeNull();
+    expect(isCatalogDetailLegacyPathTab("overview")).toBe(false);
+    expect(isCatalogDetailLegacyPathTab("foo")).toBe(false);
+    expect(isCatalogDetailLegacyPathTab("introduction")).toBe(true);
   });
 });

--- a/tests/unit/comment-panel-links.test.ts
+++ b/tests/unit/comment-panel-links.test.ts
@@ -38,12 +38,12 @@ describe("评论面板链接", () => {
     [
       "course",
       commentTargetPermalinkBaseHref({ courseJwId: 67890, type: "course" }),
-      "/catalog/courses/67890/comments#comment-comment-1",
+      "/catalog/courses/67890?tab=comments#comment-comment-1",
     ],
     [
       "teacher",
       commentTargetPermalinkBaseHref({ teacherId: 42, type: "teacher" }),
-      "/catalog/teachers/42/comments#comment-comment-1",
+      "/catalog/teachers/42?tab=comments#comment-comment-1",
     ],
   ])("根据目标类型保留 %s 评论永久链接", (_, baseHref, expected) => {
     expect(commentPermalinkHref(baseHref, "comment-1")).toBe(expected);

--- a/tests/unit/detail-page-loader-critical-path.test.ts
+++ b/tests/unit/detail-page-loader-critical-path.test.ts
@@ -243,27 +243,22 @@ describe("catalog detail loader critical path", () => {
     expect(getCommentsPayloadMock).not.toHaveBeenCalled();
   });
 
-  it("loads comments only for the course comments section", async () => {
+  it("skips comments for the course comments tab deep link", async () => {
     const { loadCourseDetailPage } = await import(
       "@/features/catalog/server/catalog-detail-page-server"
     );
 
     const result = await loadCourseDetailPage({
       locals: locals(),
-      params: { jwId: String(course.jwId), section: "comments" },
-      request: request(`/catalog/courses/${course.jwId}/comments`),
+      params: { jwId: String(course.jwId) },
+      request: request(`/catalog/courses/${course.jwId}?tab=comments`),
       url: new URL(
-        `https://example.test/catalog/courses/${course.jwId}/comments`,
+        `https://example.test/catalog/courses/${course.jwId}?tab=comments`,
       ),
     });
 
-    expect(result.commentsData).not.toBeNull();
-    expect(getCommentsPayloadMock).toHaveBeenCalledOnce();
-    expect(getCommentsPayloadMock).toHaveBeenCalledWith(
-      { targetId: course.id, type: "course" },
-      anonymousViewer,
-      { pageSize: 20 },
-    );
+    expect(result.commentsData).toBeNull();
+    expect(getCommentsPayloadMock).not.toHaveBeenCalled();
   });
 
   it("loads description history only for the introduction section", async () => {
@@ -273,10 +268,10 @@ describe("catalog detail loader critical path", () => {
 
     await loadCourseDetailPage({
       locals: locals(),
-      params: { jwId: String(course.jwId), section: "introduction" },
-      request: request(`/catalog/courses/${course.jwId}/introduction`),
+      params: { jwId: String(course.jwId) },
+      request: request(`/catalog/courses/${course.jwId}?tab=introduction`),
       url: new URL(
-        `https://example.test/catalog/courses/${course.jwId}/introduction`,
+        `https://example.test/catalog/courses/${course.jwId}?tab=introduction`,
       ),
     });
 
@@ -307,10 +302,10 @@ describe("catalog detail loader critical path", () => {
     });
     const introduction = loadCourseDetailPage({
       locals: locals(null, true),
-      params: { jwId: String(course.jwId), section: "introduction" },
-      request: request(`/catalog/courses/${course.jwId}/introduction`),
+      params: { jwId: String(course.jwId) },
+      request: request(`/catalog/courses/${course.jwId}?tab=introduction`),
       url: new URL(
-        `https://example.test/catalog/courses/${course.jwId}/introduction`,
+        `https://example.test/catalog/courses/${course.jwId}?tab=introduction`,
       ),
     });
 
@@ -352,17 +347,17 @@ describe("catalog detail loader critical path", () => {
     const { loadTeacherDetailPage } = await import(
       "@/features/catalog/server/catalog-detail-page-server"
     );
-    const load = (section?: "sections") =>
-      loadTeacherDetailPage({
+    const load = (tab?: "sections") => {
+      const query = tab ? `?tab=${tab}` : "";
+      return loadTeacherDetailPage({
         locals: locals(null, true),
-        params: { id: String(teacher.id), section },
-        request: request(
-          `/catalog/teachers/${teacher.id}${section ? `/${section}` : ""}`,
-        ),
+        params: { id: String(teacher.id) },
+        request: request(`/catalog/teachers/${teacher.id}${query}`),
         url: new URL(
-          `https://example.test/catalog/teachers/${teacher.id}${section ? `/${section}` : ""}`,
+          `https://example.test/catalog/teachers/${teacher.id}${query}`,
         ),
       });
+    };
 
     await load();
     await load();
@@ -488,10 +483,10 @@ describe("catalog detail loader critical path", () => {
 
     const result = await loadTeacherDetailPage({
       locals: locals(),
-      params: { id: String(teacher.id), section: "sections" },
-      request: request(`/catalog/teachers/${teacher.id}/sections`),
+      params: { id: String(teacher.id) },
+      request: request(`/catalog/teachers/${teacher.id}?tab=sections`),
       url: new URL(
-        `https://example.test/catalog/teachers/${teacher.id}/sections`,
+        `https://example.test/catalog/teachers/${teacher.id}?tab=sections`,
       ),
     });
 

--- a/tests/unit/public-ssr-gateway.test.ts
+++ b/tests/unit/public-ssr-gateway.test.ts
@@ -5,9 +5,11 @@ import {
   PUBLIC_SSR_BROWSER_CACHE_CONTROL,
   PUBLIC_SSR_PAGE_EDGE_CACHE_CONTROL,
   resolvePublicSsrMode as resolveBasePublicSsrMode,
+  resolveCourseDetailTabRedirect,
   resolveLegacyCatalogRedirect,
   resolvePublicSsrLocale,
   resolveSectionDetailTabRedirect,
+  resolveTeacherDetailTabRedirect,
 } from "@/lib/cloudflare/public-ssr-gateway";
 
 function resolvePublicSsrMode(request: Request) {
@@ -45,8 +47,21 @@ describe("public SSR gateway", () => {
       "/catalog/sections/159446/calendar?page=2",
       "/catalog/sections/159446?page=2&tab=calendar",
     ],
-  ])("redirects legacy section tab path %s to query tab", (path, target) => {
-    expect(resolveSectionDetailTabRedirect(request(path))).toBe(target);
+    [
+      "/catalog/courses/11145/introduction",
+      "/catalog/courses/11145?tab=introduction",
+    ],
+    [
+      "/catalog/courses/11145/sections?page=2",
+      "/catalog/courses/11145?page=2&tab=sections",
+    ],
+    ["/catalog/teachers/42/comments", "/catalog/teachers/42?tab=comments"],
+  ])("redirects legacy catalog tab path %s to query tab", (path, target) => {
+    const redirect =
+      resolveSectionDetailTabRedirect(request(path)) ??
+      resolveCourseDetailTabRedirect(request(path)) ??
+      resolveTeacherDetailTabRedirect(request(path));
+    expect(redirect).toBe(target);
   });
 
   test("does not redirect a non-read legacy request", () => {
@@ -80,26 +95,26 @@ describe("public SSR gateway", () => {
 
   test.each([
     "/catalog/courses/11145",
-    "/catalog/courses/11145/introduction",
-    "/catalog/courses/11145/sections",
-    "/catalog/courses/11145/comments",
     "/catalog/teachers/42",
-    "/catalog/teachers/42/introduction",
-    "/catalog/teachers/42/sections",
-    "/catalog/teachers/42/comments",
     "/catalog/sections/159446",
   ])("caches canonical anonymous catalog detail page %s", (path) => {
     expect(resolvePublicSsrMode(request(path))).toBe("page");
   });
 
   test.each([
+    "/catalog/courses/11145/introduction",
+    "/catalog/courses/11145/sections",
+    "/catalog/courses/11145/comments",
+    "/catalog/teachers/42/introduction",
+    "/catalog/teachers/42/sections",
+    "/catalog/teachers/42/comments",
     "/catalog/sections/159446/introduction",
     "/catalog/sections/159446/calendar",
     "/catalog/sections/159446/exams",
     "/catalog/sections/159446/homework",
     "/catalog/sections/159446/teachers",
     "/catalog/sections/159446/comments",
-  ])("bypasses legacy section tab path %s", (path) => {
+  ])("bypasses legacy catalog tab path %s", (path) => {
     expect(resolvePublicSsrMode(request(path))).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- Collapse course and teacher detail tab routes into a single SSR shell with `?tab=` client navigation, mirroring section detail (#703).
- Add 308 redirects from legacy `/catalog/courses/{id}/{tab}` and `/catalog/teachers/{id}/{tab}` paths in the worker and public SSR gateway.
- Lazy-load tab panel components and the tab data store on first navigation so the overview shell stays within the public client budget.

## Test plan
- [x] `public-route-client-budget.test.sh` passes (`/`, `/catalog/courses/[jwId]`, `/catalog/sections/[jwId]`)
- [x] Unit tests: `catalog-detail-tab`, `public-ssr-gateway`, `comment-panel-links`, `detail-page-loader-critical-path`
- [ ] E2E: course/teacher tab navigation and legacy path redirects
- [ ] Post-deploy: confirm drop in `/catalog/courses/[jwId]/[section]` and `/catalog/teachers/[id]/[section]` SSR counts

Closes #710