### PR TITLE
fix(comments): grant the app role EXECUTE on comment_hidden_root_count

### DIFF
--- a/prisma/migrations/20260803120000_comment_hidden_count_runtime_grant/migration.sql
+++ b/prisma/migrations/20260803120000_comment_hidden_count_runtime_grant/migration.sql
@@ -1,0 +1,70 @@
+BEGIN;
+
+-- `20260802120000` revoked EXECUTE on `comment_hidden_root_count` from PUBLIC,
+-- expecting `prisma/roles/production-runtime-bootstrap.sql` to hand the app role
+-- an explicit grant. Where that bootstrap has not been re-run since the function
+-- was created, `life_ustc_runtime` lost the implicit PUBLIC grant and never
+-- gained its own, so every anonymous comment list failed with Prisma P2010
+-- (raw query failed) on `SELECT public.comment_hidden_root_count(...)`.
+--
+-- 20260802120000 is already recorded as applied, so it will not re-run; this
+-- migration carries the grant instead. It is idempotent and safe on databases
+-- that already have it.
+DO $do$
+DECLARE
+  fn_signature CONSTANT text :=
+    'public.comment_hidden_root_count(integer, integer, integer, text, integer)';
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_proc AS p
+    JOIN pg_namespace AS n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'comment_hidden_root_count'
+  ) THEN
+    RAISE NOTICE 'comment_hidden_root_count is absent; nothing to grant.';
+    RETURN;
+  END IF;
+
+  -- Only the function owner may change its privileges. Once the roles bootstrap
+  -- has transferred ownership to `life_ustc_function_owner` it also issues this
+  -- grant, so skipping here is correct rather than a silent failure.
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_proc AS p
+    JOIN pg_namespace AS n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'comment_hidden_root_count'
+      AND pg_get_userbyid(p.proowner) = current_user
+  ) THEN
+    RAISE NOTICE
+      'comment_hidden_root_count is not owned by %; leaving privileges to the roles bootstrap.',
+      current_user;
+    RETURN;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'life_ustc_runtime') THEN
+    EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO life_ustc_runtime', fn_signature);
+  END IF;
+
+  -- The definer reads `Comment`, which has FORCE ROW LEVEL SECURITY, and no
+  -- other policy exposes `logged_in_only` rows. `20260802120000` bound this
+  -- policy with `TO CURRENT_USER`, which is the migrator rather than whichever
+  -- role ends up owning the function, so re-point it at the current owner.
+  IF EXISTS (SELECT 1 FROM pg_policy WHERE polname = 'Comment_hidden_count_reader')
+  THEN
+    EXECUTE format(
+      'ALTER POLICY "Comment_hidden_count_reader" ON "Comment" TO %I',
+      current_user
+    );
+  ELSE
+    EXECUTE format(
+      'CREATE POLICY "Comment_hidden_count_reader" ON "Comment"'
+      || ' FOR SELECT TO %I USING (true)',
+      current_user
+    );
+  END IF;
+END
+$do$;
+
+COMMIT;


### PR DESCRIPTION
Refs #729. The anonymous comment 500 is **still live** — #734 fixed the wrong half of the problem.

## What #734 got wrong

#734 assumed the function `comment_hidden_root_count` did not exist, because it was missing from my local dev database and the checksum showed `20260801120000` had been applied from an earlier revision. That was true locally and a red herring for production.

Production told a different story once it was asked properly:

```
DB Migrate Deploy (after #734 merged):  "No pending migrations to apply."
```

So production already had `20260802120000` recorded as applied — from the original version — which means the function existed when it ran, and the corrected migration in #734 will never re-run.

## What is actually broken

The Prisma error code that #734 added to production logs identified it immediately:

```json
{"message":"Failed to fetch comments","error":{"name":"PrismaClientKnownRequestError","code":"P2010"},"status":500}
```

`P2010` is "raw query failed" — the `$queryRaw` calling `comment_hidden_root_count`. The function exists; the app role cannot execute it.

`20260802120000` ran `REVOKE ALL ON FUNCTION ... FROM PUBLIC`, expecting `prisma/roles/production-runtime-bootstrap.sql` to hand `life_ustc_runtime` an explicit grant. That bootstrap has not been re-run since the function was created, so the role lost its implicit PUBLIC grant and never received its own.

This is also self-consistent evidence that the migrator still owns the function: had the bootstrap run, it would have transferred ownership *and* issued the grant.

## The fix

A new migration, because `20260802120000` is already recorded as applied:

- `GRANT EXECUTE` on the function to `life_ustc_runtime`, guarded on the role existing.
- Re-point `Comment_hidden_count_reader` at whichever role owns the function. The original bound it `TO CURRENT_USER`, which is the migrator rather than the eventual owner — under `FORCE ROW LEVEL SECURITY` on `Comment`, and with no other policy exposing `logged_in_only` rows, a mis-bound policy makes the definer count zero.

Both are guarded on the migrator owning the function, since only the owner may change its privileges. Once the bootstrap moves ownership to `life_ustc_function_owner`, it issues the same grant itself, so skipping is correct rather than a silent failure.

## Test plan

- [x] Applies cleanly on the local database
- [x] Re-running the SQL directly is idempotent
- [x] `tests/integration/comment-list-anonymous.test.ts` (added in #734) still passes
- [x] `biome check`, 259 integration tests
- [ ] The real proof is production: `GET /api/community/comments?targetType=section&targetId=1` should return 200 after `DB Migrate Deploy` runs on merge

## If this still does not fix it

The remaining possibility is that ownership *has* moved to `life_ustc_function_owner`, in which case this migration skips and `prisma/roles/production-runtime-bootstrap.sql` needs a manual re-run to issue the grant and re-bind the policy.

<!-- project-relationship:start -->
## Project relationship

Part of #601.
<!-- project-relationship:end -->