### PR TITLE
fix(db): stop Cloudflare 500s from missing User grants

### DIFF
--- a/prisma/migrations/20260806120000_grant_user_calendar_feed_token_update/migration.sql
+++ b/prisma/migrations/20260806120000_grant_user_calendar_feed_token_update/migration.sql
@@ -1,0 +1,15 @@
+-- Allow the app runtime to mint User.calendarFeedToken for ICS feed URLs.
+-- Workspace/calendar/subscriptions/section SSR call ensureUserCalendarFeedToken
+-- when the token is null; without this column grant those loads 500.
+
+DO $grant_user_calendar_feed_token$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'life_ustc_runtime') THEN
+    RAISE NOTICE 'Skipping User.calendarFeedToken grant; role life_ustc_runtime does not exist.';
+    RETURN;
+  END IF;
+
+  EXECUTE
+    'GRANT UPDATE ("calendarFeedToken") ON TABLE "User" TO life_ustc_runtime';
+END
+$grant_user_calendar_feed_token$;

--- a/prisma/roles/app-runtime-table-grants.sql
+++ b/prisma/roles/app-runtime-table-grants.sql
@@ -61,5 +61,5 @@ GRANT INSERT ON TABLE "AuditLog" TO life_ustc_runtime;
 GRANT SELECT, INSERT, UPDATE ON TABLE "UserSuspension" TO life_ustc_runtime;
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "BusScheduleVersion"
 TO life_ustc_runtime;
-GRANT UPDATE ("name", "username", "isAdmin") ON TABLE "User"
+GRANT UPDATE ("name", "username", "isAdmin", "calendarFeedToken") ON TABLE "User"
 TO life_ustc_runtime;

--- a/src/features/admin/server/admin-user-read-model.ts
+++ b/src/features/admin/server/admin-user-read-model.ts
@@ -16,11 +16,11 @@ type AdminUserReadPrisma = Pick<PrismaClient, "user">;
 
 type AdminUserListRow = {
   createdAt: Date;
+  email: string;
   id: string;
   isAdmin: boolean;
   name: string | null;
   username: string | null;
-  verifiedEmails: Array<{ email: string }>;
   suspensions?: Array<{
     expiresAt: Date | null;
     id: string;
@@ -46,13 +46,9 @@ const adminUserListSelect = {
   id: true,
   name: true,
   username: true,
+  email: true,
   isAdmin: true,
   createdAt: true,
-  verifiedEmails: {
-    select: { email: true },
-    orderBy: { createdAt: "desc" },
-    take: 1,
-  },
 } satisfies Prisma.UserSelect;
 
 function normalizeAdminUsersSearch(search: string | null | undefined) {
@@ -69,7 +65,7 @@ export function buildAdminUsersWhere(
           { id: ilike(normalized) },
           { name: ilike(normalized) },
           { username: ilike(normalized) },
-          { verifiedEmails: { some: { email: ilike(normalized) } } },
+          { email: ilike(normalized) },
         ],
       }
     : {};
@@ -83,7 +79,7 @@ export function toAdminUserListItem(user: AdminUserListRow): AdminUserListItem {
     name: user.name,
     username: user.username,
     isAdmin: user.isAdmin,
-    email: user.verifiedEmails[0]?.email ?? null,
+    email: user.email,
     createdAt: user.createdAt,
     ...(user.suspensions === undefined
       ? {}

--- a/src/lib/log/app-logger-core.ts
+++ b/src/lib/log/app-logger-core.ts
@@ -31,27 +31,30 @@ export function shouldLog(level: AppLogLevel): boolean {
 }
 
 const PRISMA_ERROR_CODE_PATTERN = /^P\d{4}$/;
+const SQLSTATE_CODE_PATTERN = /^[0-9A-Z]{5}$/;
 
 /**
- * Prisma error codes are stable, documented identifiers with no request data in
- * them, so they are safe to keep in production where the message is not.
- * Without the code a production `PrismaClientKnownRequestError` is undiagnosable.
+ * Prisma `P####` codes and PostgreSQL SQLSTATE codes are stable, documented
+ * identifiers with no request data in them, so they are safe to keep in
+ * production where the message is not. Without the code a production
+ * permission or constraint failure is undiagnosable.
  */
-function safePrismaErrorCode(error: unknown) {
+function safeDatabaseErrorCode(error: unknown) {
   if (typeof error !== "object" || error === null || !("code" in error)) {
     return undefined;
   }
   const { code } = error as { code: unknown };
-  return typeof code === "string" && PRISMA_ERROR_CODE_PATTERN.test(code)
-    ? code
-    : undefined;
+  if (typeof code !== "string") return undefined;
+  if (PRISMA_ERROR_CODE_PATTERN.test(code)) return code;
+  if (SQLSTATE_CODE_PATTERN.test(code)) return code;
+  return undefined;
 }
 
 export function serializeError(error: unknown) {
   if (!error) return undefined;
 
   if (isProductionEnvironment()) {
-    const code = safePrismaErrorCode(error);
+    const code = safeDatabaseErrorCode(error);
     return { name: getSafeErrorName(error), ...(code ? { code } : {}) };
   }
 

--- a/src/lib/log/safe-error-name.ts
+++ b/src/lib/log/safe-error-name.ts
@@ -1,6 +1,10 @@
 const SAFE_ERROR_NAMES = new Set([
   "AbortError",
+  "APIError",
+  "AggregateError",
   "DOMException",
+  "DevalueError",
+  "DriverAdapterError",
   "Error",
   "EvalError",
   "McpError",
@@ -19,9 +23,38 @@ const SAFE_ERROR_NAMES = new Set([
   "ZodError",
 ]);
 
+function readErrorName(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    return error.name;
+  }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    typeof (error as { name: unknown }).name === "string"
+  ) {
+    return (error as { name: string }).name;
+  }
+  return undefined;
+}
+
+/**
+ * node-pg `DatabaseError` uses lowercase name `"error"`. Map it to the
+ * allowlisted Postgres label so production logs stay diagnosable without
+ * leaking the message.
+ */
+function normalizeSafeErrorName(name: string) {
+  if (name === "error") return "PostgresError";
+  return name;
+}
+
 export function getSafeErrorName(error: unknown) {
-  if (!(error instanceof Error) || !SAFE_ERROR_NAMES.has(error.name)) {
+  const name = readErrorName(error);
+  if (!name) return "UnknownError";
+
+  const normalized = normalizeSafeErrorName(name);
+  if (!SAFE_ERROR_NAMES.has(normalized)) {
     return "UnknownError";
   }
-  return error.name;
+  return normalized;
 }

--- a/tests/unit/admin-user-read-model.test.ts
+++ b/tests/unit/admin-user-read-model.test.ts
@@ -11,11 +11,7 @@ describe("admin 用户读取模型", () => {
         { id: { contains: "alice", mode: "insensitive" } },
         { name: { contains: "alice", mode: "insensitive" } },
         { username: { contains: "alice", mode: "insensitive" } },
-        {
-          verifiedEmails: {
-            some: { email: { contains: "alice", mode: "insensitive" } },
-          },
-        },
+        { email: { contains: "alice", mode: "insensitive" } },
       ],
     });
   });
@@ -25,9 +21,9 @@ describe("admin 用户读取模型", () => {
       id: "user-1",
       name: "Alice",
       username: "alice",
+      email: "alice@example.com",
       isAdmin: false,
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
-      verifiedEmails: [{ email: "alice@example.com" }],
     };
 
     expect(toAdminUserListItem(baseUser)).toEqual({

--- a/tests/unit/safe-error-name.test.ts
+++ b/tests/unit/safe-error-name.test.ts
@@ -4,6 +4,20 @@ import { getSafeErrorName } from "@/lib/log/safe-error-name";
 describe("safe error names", () => {
   it("keeps allowlisted runtime error classes", () => {
     expect(getSafeErrorName(new TypeError("private detail"))).toBe("TypeError");
+    expect(getSafeErrorName(new AggregateError([]))).toBe("AggregateError");
+  });
+
+  it("maps node-pg DatabaseError name to PostgresError", () => {
+    const error = new Error("permission denied for column calendarFeedToken");
+    error.name = "error";
+
+    expect(getSafeErrorName(error)).toBe("PostgresError");
+  });
+
+  it("accepts duck-typed DriverAdapterError names without instanceof", () => {
+    expect(getSafeErrorName({ name: "DriverAdapterError" })).toBe(
+      "DriverAdapterError",
+    );
   });
 
   it("rejects arbitrary error names even when they look like identifiers", () => {


### PR DESCRIPTION
## Summary
- Production Cloudflare logs showed recurring `sveltekit.server-error` / `UnknownError` 500s on `/workspace/subscriptions`, `/workspace/calendar`, `/workspace/exams`, authenticated `/catalog/sections/[jwId]`, and `/admin/users`.
- Root cause for workspace + section auth loads: `ensureUserCalendarFeedToken` updates `User.calendarFeedToken`, but `life_ustc_runtime` only had `UPDATE (name, username, isAdmin)`. Grant applied to production and recorded as migration `20260806120000_grant_user_calendar_feed_token_update`.
- Root cause for `/admin/users`: `listAdminUsers` queried revoked `VerifiedEmail`; switched to `User.email`.
- Observability: allowlist pg/`DriverAdapterError`/`AggregateError`/`APIError`/`DevalueError` and keep SQLSTATE codes in production error serialization.

## Test plan
- [x] Unit tests for safe-error-name, admin-user-read-model, calendar-feed-token
- [x] Production column privilege verified true after grant
- [ ] After merge/deploy: confirm no new `sveltekit.server-error` on those routes

<!-- project-relationship:start -->
## Project relationship

Part of #601.
<!-- project-relationship:end -->