### PR TITLE
fix(db): grant User.updatedAt for calendar token minting

### DIFF
--- a/prisma/migrations/20260806120000_grant_user_calendar_feed_token_update/migration.sql
+++ b/prisma/migrations/20260806120000_grant_user_calendar_feed_token_update/migration.sql
@@ -1,6 +1,8 @@
 -- Allow the app runtime to mint User.calendarFeedToken for ICS feed URLs.
 -- Workspace/calendar/subscriptions/section SSR call ensureUserCalendarFeedToken
 -- when the token is null; without this column grant those loads 500.
+-- Prisma also writes updatedAt on the same UPDATE; that column is granted in
+-- 20260806123000_grant_user_updated_at.
 
 DO $grant_user_calendar_feed_token$
 BEGIN

--- a/prisma/migrations/20260806123000_grant_user_updated_at/migration.sql
+++ b/prisma/migrations/20260806123000_grant_user_updated_at/migration.sql
@@ -1,0 +1,15 @@
+-- Prisma User updates always touch updatedAt alongside mutable columns.
+-- Without this grant, calendarFeedToken minting (and other app User updates)
+-- still fail with SQLSTATE 42501 even when the target column is granted.
+
+DO $grant_user_updated_at$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'life_ustc_runtime') THEN
+    RAISE NOTICE 'Skipping User.updatedAt grant; role life_ustc_runtime does not exist.';
+    RETURN;
+  END IF;
+
+  EXECUTE
+    'GRANT UPDATE ("updatedAt") ON TABLE "User" TO life_ustc_runtime';
+END
+$grant_user_updated_at$;

--- a/prisma/roles/app-runtime-table-grants.sql
+++ b/prisma/roles/app-runtime-table-grants.sql
@@ -61,5 +61,5 @@ GRANT INSERT ON TABLE "AuditLog" TO life_ustc_runtime;
 GRANT SELECT, INSERT, UPDATE ON TABLE "UserSuspension" TO life_ustc_runtime;
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "BusScheduleVersion"
 TO life_ustc_runtime;
-GRANT UPDATE ("name", "username", "isAdmin", "calendarFeedToken") ON TABLE "User"
+GRANT UPDATE ("name", "username", "isAdmin", "calendarFeedToken", "updatedAt") ON TABLE "User"
 TO life_ustc_runtime;


### PR DESCRIPTION
## Summary
- Follow-up to #749: Prisma `user.updateMany({ calendarFeedToken })` also writes `updatedAt`.
- Without `UPDATE ("updatedAt")`, minting still failed as `life_ustc_runtime` with SQLSTATE 42501.
- Grant applied to production and recorded as migration `20260806123000_grant_user_updated_at`.

## Verification
- Under `SET LOCAL ROLE life_ustc_runtime`: Prisma mint `count: 1`, `listAdminUsers` returns emails, `VerifiedEmail` select still denied.
- `ensureUserCalendarFeedToken` succeeds after clearing a null token.

<!-- project-relationship:start -->
## Project relationship

Part of #601.
<!-- project-relationship:end -->