### PR TITLE
ci(api): enforce OpenAPI contract lifecycle

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -3,6 +3,8 @@
 | Workflow | Trigger | Jobs |
 |----------|---------|------|
 | CI (`ci.yml`) | push main, PRs | Check, integration, RLS tests, E2E artifacts/shards, optional visual regression, report publish |
+| OpenAPI compatibility | PRs | Block breaking changes unless `api-breaking-approved` is present |
+| OpenAPI consumer sync | OpenAPI changes on main, manual | Notify Bot and CLI with the exact server revision |
 | DB-backed Bun job | workflow_call | Reusable Postgres-backed Bun job |
 | DB migrate deploy | `prisma/**` on main, or manual | Production migrate deploy |
 | Release | successful CI on main | Semantic release |

--- a/.github/workflows/openapi-compatibility.yml
+++ b/.github/workflows/openapi-compatibility.yml
@@ -1,0 +1,39 @@
+name: OpenAPI compatibility
+
+on:
+  pull_request:
+    branches: ["**"]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  breaking-changes:
+    name: OpenAPI breaking changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Fetch base branch
+        shell: bash
+        run: >-
+          git fetch --no-tags --depth=1 origin
+          "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - name: Block unapproved breaking changes
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'api-breaking-approved') }}
+        uses: oasdiff/oasdiff-action/breaking@033c15c845bef10f148afb0fa781bf1b2a7fe1bf # v0.1.12
+        with:
+          base: origin/${{ github.base_ref }}:public/openapi.generated.json
+          revision: HEAD:public/openapi.generated.json
+          fail-on: WARN
+          review: false
+
+      - name: Report approved breaking changes
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'api-breaking-approved') }}
+        uses: oasdiff/oasdiff-action/breaking@033c15c845bef10f148afb0fa781bf1b2a7fe1bf # v0.1.12
+        with:
+          base: origin/${{ github.base_ref }}:public/openapi.generated.json
+          revision: HEAD:public/openapi.generated.json
+          review: false

--- a/.github/workflows/openapi-consumer-sync.yml
+++ b/.github/workflows/openapi-consumer-sync.yml
@@ -1,0 +1,40 @@
+name: OpenAPI consumer sync
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - public/openapi.generated.json
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    name: Notify OpenAPI consumers
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Dispatch exact server revision
+        shell: bash
+        # OPENAPI_SYNC_TOKEN needs repository dispatch access to Life-USTC/bot
+        # and Life-USTC/cli. The scheduled consumer checks cover a missing token.
+        env:
+          GH_TOKEN: ${{ secrets.OPENAPI_SYNC_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::warning::OPENAPI_SYNC_TOKEN is not configured; consumer dispatch was skipped."
+            echo "### OpenAPI consumer dispatch skipped" >> "$GITHUB_STEP_SUMMARY"
+            echo "OPENAPI_SYNC_TOKEN is not configured; scheduled consumer checks remain the fallback." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          for repository in Life-USTC/bot Life-USTC/cli; do
+            gh api --method POST "repos/${repository}/dispatches" \
+              --field event_type=openapi-updated \
+              --field "client_payload[server_sha]=${GITHUB_SHA}"
+          done
+
+          echo "### OpenAPI consumers notified" >> "$GITHUB_STEP_SUMMARY"
+          echo "Dispatched server revision \`${GITHUB_SHA}\` to Life-USTC/bot and Life-USTC/cli." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,5 +47,10 @@ Start with root [`AGENTS.md`](../AGENTS.md). For an end-to-end change, use
 - [graphql/mutation-capabilities.json](graphql/mutation-capabilities.json)
 - Generated OpenAPI: [`public/openapi.generated.json`](../public/openapi.generated.json)
 
+`bun run build` regenerates the deployed OpenAPI document. Commit that generated
+snapshot and use `bun run openapi:check` as the clean-tree drift gate. Pull
+requests with an intentional breaking change require the
+`api-breaking-approved` label; without it, compatibility warnings block CI.
+
 Production monitoring, role grants, and deploy runbooks are **not** published in
 this repository.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "dev": "vite dev --host 127.0.0.1 --port 3000 --strictPort",
-    "build": "vite build",
+    "build": "bun run openapi:generate && vite build",
     "app:prepare": "svelte-kit sync && prisma generate",
     "svelte:sync": "svelte-kit sync",
     "db:generate": "prisma generate",

--- a/tests/unit/openapi-workflow-contract.test.ts
+++ b/tests/unit/openapi-workflow-contract.test.ts
@@ -1,0 +1,56 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const actionRevision = "033c15c845bef10f148afb0fa781bf1b2a7fe1bf";
+
+async function readRepositoryFile(path: string) {
+  return readFile(new URL(`../../${path}`, import.meta.url), "utf8");
+}
+
+describe("OpenAPI build and workflow contracts", () => {
+  it("generates OpenAPI before every production build", async () => {
+    const packageJson = JSON.parse(
+      await readRepositoryFile("package.json"),
+    ) as { scripts: Record<string, string> };
+
+    expect(packageJson.scripts.build).toBe(
+      "bun run openapi:generate && vite build",
+    );
+    expect(packageJson.scripts["openapi:check"]).toBe(
+      "bun run openapi:generate && git diff --exit-code public/openapi.generated.json",
+    );
+  });
+
+  it("blocks breaking changes unless the explicit approval label is present", async () => {
+    const workflow = await readRepositoryFile(
+      ".github/workflows/openapi-compatibility.yml",
+    );
+
+    expect(workflow.match(new RegExp(actionRevision, "g"))).toHaveLength(2);
+    expect(workflow).toContain(
+      "base: origin/$" + "{{ github.base_ref }}:public/openapi.generated.json",
+    );
+    expect(workflow).toContain("revision: HEAD:public/openapi.generated.json");
+    expect(workflow).toContain("fail-on: WARN");
+    expect(workflow.match(/review: false/g)).toHaveLength(2);
+    expect(workflow).toContain("'api-breaking-approved'");
+    expect(workflow).toContain(
+      "types: [opened, synchronize, reopened, labeled, unlabeled]",
+    );
+  });
+
+  it("dispatches the immutable server revision without failing on a missing token", async () => {
+    const workflow = await readRepositoryFile(
+      ".github/workflows/openapi-consumer-sync.yml",
+    );
+
+    expect(workflow).toContain("OPENAPI_SYNC_TOKEN");
+    expect(workflow).toContain("event_type=openapi-updated");
+    expect(workflow).toContain("client_payload[server_sha]=$" + "{GITHUB_SHA}");
+    expect(workflow).toContain("Life-USTC/bot Life-USTC/cli");
+    expect(workflow).toMatch(
+      /if \[\[ -z "\$\{GH_TOKEN:-\}" \]\];[\s\S]*exit 0/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- generate the OpenAPI snapshot in the canonical production build
- gate unapproved breaking changes with pinned oasdiff
- dispatch exact server revisions to Bot and CLI consumers

## Validation
- `bun run openapi:check`
- production build and focused workflow tests
- actionlint and YAML validation

Consumer dispatch needs `OPENAPI_SYNC_TOKEN`; daily consumer sync remains the fallback when it is absent.

<!-- project-relationship:start -->
## Project relationship

Part of https://github.com/Life-USTC/server/issues/1101.
<!-- project-relationship:end -->