### PR TITLE
perf(db): reuse overview RLS transaction

### DIFF
--- a/src/features/dashboard/server/compact-overview-read-model.ts
+++ b/src/features/dashboard/server/compact-overview-read-model.ts
@@ -1,7 +1,7 @@
 import { loadOverviewTodoBundle } from "@/features/todos/server/todo-service";
 import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
 import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
-import { withUserDbContext } from "@/lib/db/prisma";
+import { withLocalizedUserDbContext, withUserDbContext } from "@/lib/db/prisma";
 import {
   type WorkspaceOverviewStage,
   writeWorkspaceOverviewStageAnalytics,
@@ -54,6 +54,33 @@ export async function getCompactOverview(
     limit?: number;
     locale?: AppLocale;
   } = {},
+) {
+  return withLocalizedUserDbContext(locale, userId, () =>
+    loadCompactOverview(userId, {
+      atTime,
+      homeworkWindowDays,
+      includeSamples,
+      limit,
+      locale,
+    }),
+  );
+}
+
+async function loadCompactOverview(
+  userId: string,
+  {
+    atTime,
+    homeworkWindowDays,
+    includeSamples,
+    limit,
+    locale,
+  }: {
+    atTime: Date;
+    homeworkWindowDays: number;
+    includeSamples: boolean;
+    limit: number;
+    locale: AppLocale;
+  },
 ) {
   const todayStart = parseRequiredDateInput(formatShanghaiDate(atTime));
   const tomorrowStart = new Date(todayStart.getTime() + 24 * 60 * 60 * 1000);

--- a/src/features/subscriptions/server/subscription-homework-list.ts
+++ b/src/features/subscriptions/server/subscription-homework-list.ts
@@ -55,17 +55,15 @@ export async function fetchSubscribedHomeworkRlsSnapshot(
   query: ReturnType<typeof buildSubscribedHomeworkQuery>,
   includeItems: boolean,
 ): Promise<SubscribedHomeworkRlsSnapshot> {
-  const total = await tx.homework.count({ where: query.where });
   if (!includeItems) {
+    const total = await tx.homework.count({ where: query.where });
     return { total, homeworkIds: [], completions: [] };
   }
 
-  const { homeworkIds, completions } =
-    await fetchSubscribedHomeworkIdsAndCompletionsInTransaction(
-      tx,
-      userId,
-      query,
-    );
+  const [total, { homeworkIds, completions }] = await Promise.all([
+    tx.homework.count({ where: query.where }),
+    fetchSubscribedHomeworkIdsAndCompletionsInTransaction(tx, userId, query),
+  ]);
   return { total, homeworkIds, completions };
 }
 

--- a/src/features/subscriptions/server/subscription-schedule-exam-read-model.ts
+++ b/src/features/subscriptions/server/subscription-schedule-exam-read-model.ts
@@ -247,15 +247,17 @@ export async function listTodaySubscribedSchedulesWithCount(
         date: { gte: todayStart, lt: tomorrowStart },
       } satisfies Prisma.ScheduleWhereInput;
       const localizedPrisma = getPrisma(locale);
-      const total = await localizedPrisma.schedule.count({ where });
-      const items = includeItems
-        ? await localizedPrisma.schedule.findMany({
-            where,
-            select: overviewScheduleSelect,
-            orderBy: subscribedScheduleOrderBy,
-            ...(limit ? { take: limit } : {}),
-          })
-        : [];
+      const [total, items] = await Promise.all([
+        localizedPrisma.schedule.count({ where }),
+        includeItems
+          ? localizedPrisma.schedule.findMany({
+              where,
+              select: overviewScheduleSelect,
+              orderBy: subscribedScheduleOrderBy,
+              ...(limit ? { take: limit } : {}),
+            })
+          : Promise.resolve([]),
+      ]);
       return { total, items };
     },
     sectionIds,
@@ -283,18 +285,18 @@ export async function listUpcomingSubscribedExamsWithCount(
     userId,
     async (ids) => {
       const where = upcomingKnownExamWhere({ atTime, sectionIds: ids });
-      const total = await countUpcomingSubscribedExams({
-        atTime,
-        sectionIds: ids,
-      });
-      const items = includeItems
-        ? await getPrisma(locale).exam.findMany({
-            where,
-            select: overviewExamSelect,
-            orderBy: subscribedExamOrderBy,
-            ...(limit ? { take: limit } : {}),
-          })
-        : [];
+      const localizedPrisma = getPrisma(locale);
+      const [total, items] = await Promise.all([
+        localizedPrisma.exam.count({ where }),
+        includeItems
+          ? localizedPrisma.exam.findMany({
+              where,
+              select: overviewExamSelect,
+              orderBy: subscribedExamOrderBy,
+              ...(limit ? { take: limit } : {}),
+            })
+          : Promise.resolve([]),
+      ]);
       return { total, items };
     },
     sectionIds,

--- a/src/features/todos/server/todo-service.ts
+++ b/src/features/todos/server/todo-service.ts
@@ -314,7 +314,7 @@ async function loadOverviewTodoBundleInTransaction(
   },
 ) {
   const userId = normalizeTodoUserId(input.userId);
-  const fusedCounts = await countOverviewTodoBundleInTransaction(tx, {
+  const fusedCountsPromise = countOverviewTodoBundleInTransaction(tx, {
     userId,
     now: input.now,
     homeworkWindowEnd: input.homeworkWindowEnd,
@@ -326,7 +326,8 @@ async function loadOverviewTodoBundleInTransaction(
     dueAtTo: input.homeworkWindowEnd,
     includeDueAtTo: true as const,
   };
-  const [todos, dueTodos] = await Promise.all([
+  const [fusedCounts, todos, dueTodos] = await Promise.all([
+    fusedCountsPromise,
     input.includeSamples
       ? findTodoSnapshots(tx, {
           where: buildTodoListWhere(userId, { completed: false }),

--- a/tests/unit/compact-overview-read-model.test.ts
+++ b/tests/unit/compact-overview-read-model.test.ts
@@ -8,6 +8,7 @@ const {
   loadOverviewTodoBundleMock,
   runCloudflareTraceSpanMock,
   userFindUniqueMock,
+  withLocalizedUserDbContextMock,
   withUserDbContextMock,
 } = vi.hoisted(() => {
   const userFindUnique = vi.fn();
@@ -21,6 +22,13 @@ const {
         callback(),
     ),
     userFindUniqueMock: userFindUnique,
+    withLocalizedUserDbContextMock: vi.fn(
+      async (
+        _locale: string,
+        _userId: string,
+        action: () => Promise<unknown>,
+      ) => action(),
+    ),
     withUserDbContextMock: vi.fn(
       async (
         _userId: string,
@@ -35,6 +43,7 @@ vi.mock("@/lib/adapters/cloudflare-runtime", () => ({
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
+  withLocalizedUserDbContext: withLocalizedUserDbContextMock,
   withUserDbContext: withUserDbContextMock,
 }));
 
@@ -111,6 +120,12 @@ describe("compact workspace overview read model", () => {
     const overview = await getCompactOverview("user-1", { atTime: AT_TIME });
 
     expect(userFindUniqueMock).toHaveBeenCalledOnce();
+    expect(withLocalizedUserDbContextMock).toHaveBeenCalledOnce();
+    expect(withLocalizedUserDbContextMock).toHaveBeenCalledWith(
+      "zh-cn",
+      "user-1",
+      expect.any(Function),
+    );
     expect(userFindUniqueMock).toHaveBeenCalledWith({
       where: { id: "user-1" },
       select: {

--- a/tests/unit/subscription-overview-read-concurrency.test.ts
+++ b/tests/unit/subscription-overview-read-concurrency.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../shared/deferred";
+
+const {
+  examCountMock,
+  examFindManyMock,
+  scheduleCountMock,
+  scheduleFindManyMock,
+} = vi.hoisted(() => ({
+  examCountMock: vi.fn(),
+  examFindManyMock: vi.fn(),
+  scheduleCountMock: vi.fn(),
+  scheduleFindManyMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  getPrisma: vi.fn(() => ({
+    exam: { count: examCountMock, findMany: examFindManyMock },
+    schedule: { count: scheduleCountMock, findMany: scheduleFindManyMock },
+  })),
+  prisma: { exam: { count: examCountMock } },
+}));
+
+vi.mock(
+  "@/features/subscriptions/server/subscription-read-model-shared",
+  () => ({
+    getSubscribedSectionIds: vi.fn(),
+    getSubscribedSectionIdsForSemester: vi.fn(),
+    withSubscribedSections: vi.fn(
+      async (
+        _userId: string,
+        action: (ids: number[]) => Promise<unknown>,
+        sectionIds?: readonly number[],
+      ) => action(Array.from(sectionIds ?? [])),
+    ),
+  }),
+);
+
+describe("subscription overview count and sample reads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts the schedule sample without waiting for the count", async () => {
+    const { promise: countPromise, resolve: resolveCount } =
+      createDeferred<number>();
+    scheduleCountMock.mockReturnValue(countPromise);
+    scheduleFindManyMock.mockResolvedValue([{ id: 101 }]);
+    const { listTodaySubscribedSchedulesWithCount } = await import(
+      "@/features/subscriptions/server/subscription-schedule-exam-read-model"
+    );
+
+    const resultPromise = listTodaySubscribedSchedulesWithCount("user-1", {
+      todayStart: new Date("2026-05-01T00:00:00+08:00"),
+      tomorrowStart: new Date("2026-05-02T00:00:00+08:00"),
+      limit: 3,
+      sectionIds: [11],
+    });
+
+    await vi.waitFor(() => expect(scheduleFindManyMock).toHaveBeenCalledOnce());
+    resolveCount(4);
+    await expect(resultPromise).resolves.toEqual({
+      total: 4,
+      items: [{ id: 101 }],
+    });
+  });
+
+  it("starts the exam sample without waiting for the count", async () => {
+    const { promise: countPromise, resolve: resolveCount } =
+      createDeferred<number>();
+    examCountMock.mockReturnValue(countPromise);
+    examFindManyMock.mockResolvedValue([{ id: 201 }]);
+    const { listUpcomingSubscribedExamsWithCount } = await import(
+      "@/features/subscriptions/server/subscription-schedule-exam-read-model"
+    );
+
+    const resultPromise = listUpcomingSubscribedExamsWithCount("user-1", {
+      atTime: new Date("2026-05-01T10:00:00+08:00"),
+      limit: 3,
+      sectionIds: [11],
+    });
+
+    await vi.waitFor(() => expect(examFindManyMock).toHaveBeenCalledOnce());
+    resolveCount(5);
+    await expect(resultPromise).resolves.toEqual({
+      total: 5,
+      items: [{ id: 201 }],
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n- execute the compact workspace overview inside one localized RLS transaction\n- reuse the active transaction in nested reads\n- parallelize independent todo, schedule, exam, and homework reads\n\n## Performance impact\n- reduces standalone overview RLS transactions from 4 to 1\n- reduces transaction-control round trips from 12 to 3\n\n## Validation\n- full unit suite: 333 files / 2014 tests\n- focused DB integration tests\n- TypeScript, Svelte, Biome, and diff checks

<!-- project-relationship:start -->
## Project relationship

Part of #601.
<!-- project-relationship:end -->