### PR TITLE
fix(subscriptions): keep computed names out of RLS queries

### DIFF
--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -19086,34 +19086,6 @@
                             "nullable": true,
                             "type": "string"
                           },
-                          "email": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "telephone": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "mobile": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "address": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "departmentId": {
-                            "nullable": true,
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
-                          },
-                          "teacherTitleId": {
-                            "nullable": true,
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
-                          },
                           "namePrimary": {
                             "type": "string"
                           },
@@ -19129,12 +19101,6 @@
                           "code",
                           "nameCn",
                           "nameEn",
-                          "email",
-                          "telephone",
-                          "mobile",
-                          "address",
-                          "departmentId",
-                          "teacherTitleId",
                           "namePrimary",
                           "nameSecondary"
                         ],
@@ -19773,34 +19739,6 @@
                             "nullable": true,
                             "type": "string"
                           },
-                          "email": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "telephone": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "mobile": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "address": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "departmentId": {
-                            "nullable": true,
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
-                          },
-                          "teacherTitleId": {
-                            "nullable": true,
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
-                          },
                           "namePrimary": {
                             "type": "string"
                           },
@@ -19816,12 +19754,6 @@
                           "code",
                           "nameCn",
                           "nameEn",
-                          "email",
-                          "telephone",
-                          "mobile",
-                          "address",
-                          "departmentId",
-                          "teacherTitleId",
                           "namePrimary",
                           "nameSecondary"
                         ],
@@ -20472,34 +20404,6 @@
                             "nullable": true,
                             "type": "string"
                           },
-                          "email": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "telephone": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "mobile": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "address": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "departmentId": {
-                            "nullable": true,
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
-                          },
-                          "teacherTitleId": {
-                            "nullable": true,
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
-                          },
                           "namePrimary": {
                             "type": "string"
                           },
@@ -20515,12 +20419,6 @@
                           "code",
                           "nameCn",
                           "nameEn",
-                          "email",
-                          "telephone",
-                          "mobile",
-                          "address",
-                          "departmentId",
-                          "teacherTitleId",
                           "namePrimary",
                           "nameSecondary"
                         ],
@@ -24752,34 +24650,6 @@
                         "nullable": true,
                         "type": "string"
                       },
-                      "email": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "telephone": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "mobile": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "address": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "departmentId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
-                      },
-                      "teacherTitleId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
-                      },
                       "namePrimary": {
                         "type": "string"
                       },
@@ -24795,12 +24665,6 @@
                       "code",
                       "nameCn",
                       "nameEn",
-                      "email",
-                      "telephone",
-                      "mobile",
-                      "address",
-                      "departmentId",
-                      "teacherTitleId",
                       "namePrimary",
                       "nameSecondary"
                     ],
@@ -27387,34 +27251,6 @@
                         "nullable": true,
                         "type": "string"
                       },
-                      "email": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "telephone": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "mobile": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "address": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "departmentId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
-                      },
-                      "teacherTitleId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
-                      },
                       "namePrimary": {
                         "type": "string"
                       },
@@ -27430,12 +27266,6 @@
                       "code",
                       "nameCn",
                       "nameEn",
-                      "email",
-                      "telephone",
-                      "mobile",
-                      "address",
-                      "departmentId",
-                      "teacherTitleId",
                       "namePrimary",
                       "nameSecondary"
                     ],
@@ -28056,34 +27886,6 @@
                             "nullable": true,
                             "type": "string"
                           },
-                          "email": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "telephone": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "mobile": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "address": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "departmentId": {
-                            "nullable": true,
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
-                          },
-                          "teacherTitleId": {
-                            "nullable": true,
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
-                          },
                           "namePrimary": {
                             "type": "string"
                           },
@@ -28099,12 +27901,6 @@
                           "code",
                           "nameCn",
                           "nameEn",
-                          "email",
-                          "telephone",
-                          "mobile",
-                          "address",
-                          "departmentId",
-                          "teacherTitleId",
                           "namePrimary",
                           "nameSecondary"
                         ],
@@ -28737,34 +28533,6 @@
                             "nullable": true,
                             "type": "string"
                           },
-                          "email": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "telephone": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "mobile": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "address": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "departmentId": {
-                            "nullable": true,
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
-                          },
-                          "teacherTitleId": {
-                            "nullable": true,
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
-                          },
                           "namePrimary": {
                             "type": "string"
                           },
@@ -28780,12 +28548,6 @@
                           "code",
                           "nameCn",
                           "nameEn",
-                          "email",
-                          "telephone",
-                          "mobile",
-                          "address",
-                          "departmentId",
-                          "teacherTitleId",
                           "namePrimary",
                           "nameSecondary"
                         ],
@@ -29444,34 +29206,6 @@
                         "nullable": true,
                         "type": "string"
                       },
-                      "email": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "telephone": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "mobile": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "address": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "departmentId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
-                      },
-                      "teacherTitleId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
-                      },
                       "namePrimary": {
                         "type": "string"
                       },
@@ -29487,12 +29221,6 @@
                       "code",
                       "nameCn",
                       "nameEn",
-                      "email",
-                      "telephone",
-                      "mobile",
-                      "address",
-                      "departmentId",
-                      "teacherTitleId",
                       "namePrimary",
                       "nameSecondary"
                     ],
@@ -30083,34 +29811,6 @@
                         "nullable": true,
                         "type": "string"
                       },
-                      "email": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "telephone": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "mobile": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "address": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "departmentId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
-                      },
-                      "teacherTitleId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
-                      },
                       "namePrimary": {
                         "type": "string"
                       },
@@ -30126,12 +29826,6 @@
                       "code",
                       "nameCn",
                       "nameEn",
-                      "email",
-                      "telephone",
-                      "mobile",
-                      "address",
-                      "departmentId",
-                      "teacherTitleId",
                       "namePrimary",
                       "nameSecondary"
                     ],
@@ -30722,34 +30416,6 @@
                         "nullable": true,
                         "type": "string"
                       },
-                      "email": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "telephone": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "mobile": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "address": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "departmentId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
-                      },
-                      "teacherTitleId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
-                      },
                       "namePrimary": {
                         "type": "string"
                       },
@@ -30765,12 +30431,6 @@
                       "code",
                       "nameCn",
                       "nameEn",
-                      "email",
-                      "telephone",
-                      "mobile",
-                      "address",
-                      "departmentId",
-                      "teacherTitleId",
                       "namePrimary",
                       "nameSecondary"
                     ],
@@ -31363,34 +31023,6 @@
                             "nullable": true,
                             "type": "string"
                           },
-                          "email": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "telephone": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "mobile": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "address": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "departmentId": {
-                            "nullable": true,
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
-                          },
-                          "teacherTitleId": {
-                            "nullable": true,
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
-                          },
                           "namePrimary": {
                             "type": "string"
                           },
@@ -31406,12 +31038,6 @@
                           "code",
                           "nameCn",
                           "nameEn",
-                          "email",
-                          "telephone",
-                          "mobile",
-                          "address",
-                          "departmentId",
-                          "teacherTitleId",
                           "namePrimary",
                           "nameSecondary"
                         ],
@@ -32131,34 +31757,6 @@
                         "nullable": true,
                         "type": "string"
                       },
-                      "email": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "telephone": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "mobile": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "address": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "departmentId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
-                      },
-                      "teacherTitleId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
-                      },
                       "namePrimary": {
                         "type": "string"
                       },
@@ -32174,12 +31772,6 @@
                       "code",
                       "nameCn",
                       "nameEn",
-                      "email",
-                      "telephone",
-                      "mobile",
-                      "address",
-                      "departmentId",
-                      "teacherTitleId",
                       "namePrimary",
                       "nameSecondary"
                     ],

--- a/src/features/subscriptions/server/subscription-calendar-read-model.ts
+++ b/src/features/subscriptions/server/subscription-calendar-read-model.ts
@@ -1,4 +1,3 @@
-import { sectionCompactInclude } from "@/features/catalog/server/academic-query-includes";
 import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
 import { prisma, withUserDbContext } from "@/lib/db/prisma";
 import { logAppEvent } from "@/lib/log/app-logger";
@@ -9,6 +8,7 @@ import {
   type UserSectionSubscriptionState,
   userSectionSubscriptionSelect,
 } from "./subscription-read-model-shared";
+import { subscriptionSectionCompactInclude } from "./subscription-section-include";
 import { localizeCompactSubscriptionSection } from "./subscription-section-localize";
 
 export async function getUserSectionSubscriptionState(
@@ -47,7 +47,7 @@ export async function getUserCalendarSubscription(
         sectionSubscriptions: {
           include: {
             section: {
-              include: sectionCompactInclude,
+              include: subscriptionSectionCompactInclude,
             },
           },
           orderBy: [

--- a/src/features/subscriptions/server/subscription-section-include.ts
+++ b/src/features/subscriptions/server/subscription-section-include.ts
@@ -1,0 +1,32 @@
+import type { Prisma } from "@/generated/prisma/client";
+
+/**
+ * Workspace subscription reads can run on Prisma's raw RLS transaction client,
+ * so this projection contains database fields only. Localized computed names are
+ * added after the query by `localizeCompactSubscriptionSection`.
+ */
+export const subscriptionSectionCompactInclude = {
+  course: {
+    include: {
+      educationLevel: true,
+      category: true,
+      classify: true,
+      classType: true,
+      gradation: true,
+      type: true,
+    },
+  },
+  semester: true,
+  campus: true,
+  openDepartment: true,
+  teachers: {
+    select: {
+      id: true,
+      jwId: true,
+      personId: true,
+      code: true,
+      nameCn: true,
+      nameEn: true,
+    },
+  },
+} satisfies Prisma.SectionInclude;

--- a/src/features/subscriptions/server/subscription-section-resolver.ts
+++ b/src/features/subscriptions/server/subscription-section-resolver.ts
@@ -1,4 +1,3 @@
-import { sectionCompactInclude } from "@/features/catalog/server/academic-query-includes";
 import { resolveSectionCodeMatchSemester } from "@/features/catalog/server/section-code-match-semester";
 import { buildSectionCodeSuggestions } from "@/features/catalog/server/section-code-match-suggestions";
 import type { Prisma } from "@/generated/prisma/client";
@@ -6,6 +5,8 @@ import type { AppLocale } from "@/i18n/config";
 import { DEFAULT_LOCALE } from "@/i18n/config";
 import { getPrisma } from "@/lib/db/prisma";
 import { uniqueSectionIds } from "./subscription-section-id-helpers";
+import { subscriptionSectionCompactInclude } from "./subscription-section-include";
+import { localizeCompactSubscriptionSection } from "./subscription-section-localize";
 
 function uniqueCodes(codes: readonly string[] = []) {
   const seen = new Set<string>();
@@ -69,18 +70,21 @@ export async function resolveCalendarSubscriptionSections({
   }
 
   const localizedPrisma = getPrisma(locale);
-  const sections =
+  const sectionRows =
     where.length === 0
       ? []
       : await localizedPrisma.section.findMany({
           where: where.length === 1 ? where[0] : { OR: where },
-          include: sectionCompactInclude,
+          include: subscriptionSectionCompactInclude,
           orderBy: [
             { semester: { jwId: "desc" } },
             { code: "asc" },
             { jwId: "asc" },
           ],
         });
+  const sections = sectionRows.map((section) =>
+    localizeCompactSubscriptionSection(section, locale),
+  );
 
   const foundSectionIds = new Set(sections.map((section) => section.id));
   const requestedCodeByNormalized = new Map(

--- a/src/lib/api/schemas/academic-section-list-response-schemas.ts
+++ b/src/lib/api/schemas/academic-section-list-response-schemas.ts
@@ -13,7 +13,6 @@ import {
 import {
   departmentSchema,
   teacherPublicIdentitySchema,
-  teacherSchema,
   teacherWithDepartmentTitleSchema,
 } from "./academic-teacher-response-schemas";
 
@@ -25,7 +24,7 @@ const localizedNameFields = {
 const localizedCourseSchema = courseSchema.extend(localizedNameFields);
 const localizedCampusSchema = campusSchema.extend(localizedNameFields);
 const localizedDepartmentSchema = departmentSchema.extend(localizedNameFields);
-const localizedTeacherSchema = teacherSchema.extend(localizedNameFields);
+const localizedTeacherSchema = teacherPublicIdentitySchema;
 
 const courseSummarySchema = z.object({
   id: z.number().int(),

--- a/tests/unit/public-teacher-payload.test.ts
+++ b/tests/unit/public-teacher-payload.test.ts
@@ -10,6 +10,7 @@ import {
   teacherPublicListSelect,
   teacherPublicReferenceSelect,
 } from "@/features/catalog/server/academic-query-includes";
+import { sectionCompactSchema } from "@/lib/api/schemas/academic-section-list-response-schemas";
 
 const sourceOnlyTeacherFields = ["age", "postcode", "qq", "wechat"];
 const teacherContactFields = ["email", "telephone", "mobile", "address"];
@@ -32,6 +33,24 @@ describe("public teacher payloads", () => {
       expect(teacherPublicIdentitySelect).not.toHaveProperty(field);
       expect(teacherPublicReferenceSelect).not.toHaveProperty(field);
     }
+  });
+
+  it("accepts compact section teachers without private contact fields", () => {
+    const teacher = sectionCompactSchema.shape.teachers.element.parse({
+      id: 1,
+      jwId: 9910101,
+      personId: null,
+      code: "T2401001",
+      nameCn: "林老师",
+      nameEn: "Professor Lin",
+      namePrimary: "林老师",
+      nameSecondary: "Professor Lin",
+    });
+
+    expect(teacher).not.toHaveProperty("email");
+    expect(teacher).not.toHaveProperty("telephone");
+    expect(teacher).not.toHaveProperty("mobile");
+    expect(teacher).not.toHaveProperty("address");
   });
 
   it("never exposes source-only teacher fields on list or detail", () => {

--- a/tests/unit/retired-section-discovery.test.ts
+++ b/tests/unit/retired-section-discovery.test.ts
@@ -116,6 +116,14 @@ describe("retired Section discovery boundaries", () => {
         where: { id: { in: [11] }, retiredAt: null },
       }),
     );
+    const query = sectionFindManyMock.mock.calls.at(-1)?.[0];
+    expect(query.include.teachers.select).toMatchObject({
+      id: true,
+      nameCn: true,
+      nameEn: true,
+    });
+    expect(query.include.teachers.select).not.toHaveProperty("namePrimary");
+    expect(query.include.teachers.select).not.toHaveProperty("nameSecondary");
 
     await resolveCalendarSubscriptionSections({
       includeRetired: true,

--- a/tests/unit/section-lifecycle-queries.test.ts
+++ b/tests/unit/section-lifecycle-queries.test.ts
@@ -167,6 +167,16 @@ describe("retired Section query contracts", () => {
         }),
       }),
     );
+    const query = transactionUserFindUniqueMock.mock.calls[0]?.[0];
+    const teacherSelect =
+      query.select.sectionSubscriptions.include.section.include.teachers.select;
+    expect(teacherSelect).toMatchObject({
+      id: true,
+      nameCn: true,
+      nameEn: true,
+    });
+    expect(teacherSelect).not.toHaveProperty("namePrimary");
+    expect(teacherSelect).not.toHaveProperty("nameSecondary");
     expect(localizedUserFindUniqueMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- give workspace subscription reads an explicit database-scalar section projection
- reuse it for calendar subscription reads and section resolution, including calls nested in localized RLS contexts
- apply locale-derived names only after the query completes

## Root cause
PR #820 reused the public catalog `sectionCompactInclude` in workspace code. Its nested teacher select includes Prisma result-extension fields `namePrimary` and `nameSecondary`. When workspace reads execute through a raw RLS transaction client, Prisma rejects those computed fields before issuing SQL. That broke subscription reads/imports and contaminated the later `schedule_next` fixture assertions.

The pg concurrent-query deprecation warning is independently reproducible on the prior passing code and remains outside this focused regression fix.

## Validation
- failing set before: 12 failures across the three reported integration files
- exact three-file regression set after: 36/36 passing, twice
- full MCP integration: 41 files passed, 11 skipped; 246 tests passed, 50 skipped
- unit suite: 338 files, 2035 tests passed
- TypeScript app/tests/operational checks passed
- Biome passed with 7 pre-existing warnings
- production build passed

No external API contract changed; this restores the existing response shape while preserving the public teacher-field allowlist and the shared RLS transaction optimization.

<!-- project-relationship:start -->
## Project relationship

Part of #601.
<!-- project-relationship:end -->