### PR TITLE
perf(workspace): split dashboard RLS read contexts

### DIFF
--- a/src/features/dashboard/server/compact-overview-read-model.ts
+++ b/src/features/dashboard/server/compact-overview-read-model.ts
@@ -1,7 +1,7 @@
 import { loadOverviewTodoBundle } from "@/features/todos/server/todo-service";
 import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
 import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
-import { withLocalizedUserDbContext, withUserDbContext } from "@/lib/db/prisma";
+import { withUserDbContext } from "@/lib/db/prisma";
 import { elapsedMs, monotonicNowMs } from "@/lib/log/observability-clock";
 import {
   type WorkspaceOverviewStage,
@@ -56,33 +56,9 @@ export async function getCompactOverview(
     locale?: AppLocale;
   } = {},
 ) {
-  return withLocalizedUserDbContext(locale, userId, () =>
-    loadCompactOverview(userId, {
-      atTime,
-      homeworkWindowDays,
-      includeSamples,
-      limit,
-      locale,
-    }),
-  );
-}
-
-async function loadCompactOverview(
-  userId: string,
-  {
-    atTime,
-    homeworkWindowDays,
-    includeSamples,
-    limit,
-    locale,
-  }: {
-    atTime: Date;
-    homeworkWindowDays: number;
-    includeSamples: boolean;
-    limit: number;
-    locale: AppLocale;
-  },
-) {
+  // Keep the aggregate orchestration outside a shared interactive
+  // transaction. Owner-scoped reads establish their own RLS contexts while
+  // public catalog reads can use the bounded Prisma pool concurrently.
   const todayStart = parseRequiredDateInput(formatShanghaiDate(atTime));
   const tomorrowStart = new Date(todayStart.getTime() + 24 * 60 * 60 * 1000);
   const homeworkWindowEnd = shanghaiDayjs(atTime)

--- a/src/features/dashboard/server/dashboard-page-load-signed.ts
+++ b/src/features/dashboard/server/dashboard-page-load-signed.ts
@@ -6,7 +6,6 @@ import {
 } from "@/features/dashboard/server/dashboard-page-tab-data";
 import { createDashboardStageCounter } from "@/features/dashboard/server/dashboard-stage-analytics";
 import type { AppLocale } from "@/i18n/config";
-import { withLocalizedUserDbContext } from "@/lib/db/prisma";
 import { toShanghaiIsoString } from "@/lib/time/serialize-date-output";
 
 export async function loadSignedDashboardPageData(input: {
@@ -20,83 +19,82 @@ export async function loadSignedDashboardPageData(input: {
   tab: string;
   userId: string;
 }) {
-  return withLocalizedUserDbContext(input.locale, input.userId, async () => {
-    const dashboard = await import(
-      "@/features/dashboard/server/dashboard-overview-data"
-    );
-    const userContextCounter = createDashboardStageCounter({
-      dbContext: "rls",
-      dbLabel: "app",
-    });
-    const context = await timeDashboardStage(
-      "user_context",
-      {
-        requestId: input.requestId,
-        tab: input.tab,
-      },
-      () => dashboard.getDashboardUserContext(input.userId, userContextCounter),
-      userContextCounter,
-    );
+  // Read the shell identity and subscription scope in its own short RLS
+  // transaction. The tab read models below deliberately own their RLS
+  // contexts so their fixed fan-out can use separate pool connections.
+  const dashboard = await import(
+    "@/features/dashboard/server/dashboard-overview-data"
+  );
+  const userContextCounter = createDashboardStageCounter({
+    dbContext: "rls",
+    dbLabel: "app",
+  });
+  const context = await timeDashboardStage(
+    "user_context",
+    {
+      requestId: input.requestId,
+      tab: input.tab,
+    },
+    () => dashboard.getDashboardUserContext(input.userId, userContextCounter),
+    userContextCounter,
+  );
 
-    if (!context) {
-      return {
-        copy: input.pageCopy,
-        locale: input.locale,
-        signedIn: true,
-        tab: input.tab,
-        userMissing: true,
-      };
-    }
-
-    const {
-      bus,
-      calendarSubscriptionUrl,
-      homeworks,
-      links,
-      navStats,
-      overview,
-      subscriptions,
-      todos,
-    } = await timeDashboardStage(
-      "tab",
-      {
-        requestId: input.requestId,
-        subscribedSectionCount: context.sectionIds.length,
-        tab: input.tab,
-      },
-      () =>
-        loadSignedDashboardTabData({
-          calendarSemesterId: input.calendarSemesterId,
-          context,
-          locale: input.locale,
-          overviewWeek: input.overviewWeek,
-          referenceNow: input.referenceNow ?? undefined,
-          requestId: input.requestId,
-          revealCalendarFeed: input.revealCalendarFeed,
-          tab: input.tab,
-          userId: input.userId,
-        }),
-    );
-
+  if (!context) {
     return {
       copy: input.pageCopy,
       locale: input.locale,
-      referenceNow: toShanghaiIsoString(input.referenceNow ?? new Date()),
       signedIn: true,
       tab: input.tab,
-      overviewWeek: input.overviewWeek,
-      navStats,
-      subscribedSectionCount: context.sectionIds.length,
-      overview: overview ? serializeDashboardOverview(overview) : null,
-      links,
-      homeworks,
-      subscriptions,
-      calendarSubscriptionUrl:
-        subscriptions?.calendarSubscriptionUrl ??
-        calendarSubscriptionUrl ??
-        null,
-      todos,
-      bus: bus?.data ?? null,
+      userMissing: true,
     };
-  });
+  }
+
+  const {
+    bus,
+    calendarSubscriptionUrl,
+    homeworks,
+    links,
+    navStats,
+    overview,
+    subscriptions,
+    todos,
+  } = await timeDashboardStage(
+    "tab",
+    {
+      requestId: input.requestId,
+      subscribedSectionCount: context.sectionIds.length,
+      tab: input.tab,
+    },
+    () =>
+      loadSignedDashboardTabData({
+        calendarSemesterId: input.calendarSemesterId,
+        context,
+        locale: input.locale,
+        overviewWeek: input.overviewWeek,
+        referenceNow: input.referenceNow ?? undefined,
+        requestId: input.requestId,
+        revealCalendarFeed: input.revealCalendarFeed,
+        tab: input.tab,
+        userId: input.userId,
+      }),
+  );
+
+  return {
+    copy: input.pageCopy,
+    locale: input.locale,
+    referenceNow: toShanghaiIsoString(input.referenceNow ?? new Date()),
+    signedIn: true,
+    tab: input.tab,
+    overviewWeek: input.overviewWeek,
+    navStats,
+    subscribedSectionCount: context.sectionIds.length,
+    overview: overview ? serializeDashboardOverview(overview) : null,
+    links,
+    homeworks,
+    subscriptions,
+    calendarSubscriptionUrl:
+      subscriptions?.calendarSubscriptionUrl ?? calendarSubscriptionUrl ?? null,
+    todos,
+    bus: bus?.data ?? null,
+  };
 }

--- a/src/features/dashboard/server/dashboard-page-tab-data.ts
+++ b/src/features/dashboard/server/dashboard-page-tab-data.ts
@@ -1,6 +1,5 @@
 import type { DashboardUserContext } from "@/features/dashboard/server/dashboard-user-context";
 import type { AppLocale } from "@/i18n/config";
-import { withUserDbContext } from "@/lib/db/prisma";
 import { logAppEvent } from "@/lib/log/app-logger";
 import { elapsedMs, monotonicNowMs } from "@/lib/log/observability-clock";
 import {
@@ -92,146 +91,148 @@ export async function loadSignedDashboardTabData(input: {
     subscribedSectionCount: input.context.sectionIds.length,
     tab: input.tab,
   };
-  return withUserDbContext(input.userId, async () => {
-    const shouldLoadTodos = input.tab === "todos" || input.tab === "overview";
-    const semestersPromise = timeDashboardStage("semesters", stageContext, () =>
-      dashboard.getDashboardSemesters(),
-    );
-    const todosPromise = shouldLoadTodos
-      ? timeDashboardStage("todos", stageContext, () =>
-          dashboardTabs.getTodosTabData(input.userId),
+  // Do not wrap the whole tab in one interactive transaction. Every read
+  // model establishes its own user-scoped RLS context; keeping this
+  // orchestrator context-free allows fixed Promise.all fan-out to use the
+  // pool's bounded connections instead of queueing on one connection.
+  const shouldLoadTodos = input.tab === "todos" || input.tab === "overview";
+  const semestersPromise = timeDashboardStage("semesters", stageContext, () =>
+    dashboard.getDashboardSemesters(),
+  );
+  const todosPromise = shouldLoadTodos
+    ? timeDashboardStage("todos", stageContext, () =>
+        dashboardTabs.getTodosTabData(input.userId),
+      )
+    : inactiveStage(null);
+  const pendingTodosCountPromise = shouldLoadTodos
+    ? todosPromise.then(
+        (items) => items?.filter((todo) => !todo.completed).length ?? 0,
+      )
+    : undefined;
+  const navStatsCounter = createDashboardStageCounter({
+    dbContext: "rls",
+    dbLabel: "app",
+  });
+  const navStatsPromise = timeDashboardStage(
+    "nav_stats",
+    stageContext,
+    async () =>
+      dashboard.getDashboardNavStats(
+        input.context.user,
+        input.context.subscribedSections,
+        input.referenceNow,
+        pendingTodosCountPromise,
+        await semestersPromise,
+        navStatsCounter,
+      ),
+  );
+  const overviewPromise =
+    input.tab === "overview" || input.tab === "calendar"
+      ? timeDashboardStage("overview", stageContext, async () => {
+          const [semesters, overviewTodos] = await Promise.all([
+            semestersPromise,
+            todosPromise,
+          ]);
+          return dashboard.getDashboardOverviewData(input.userId, {
+            calendarMode: input.tab === "calendar" ? "semester" : "preview",
+            calendarSemesterId: input.calendarSemesterId,
+            calendarTodos:
+              overviewTodos?.flatMap((todo) =>
+                !todo.completed && todo.dueAt
+                  ? [
+                      {
+                        completed: false,
+                        content: todo.content,
+                        dueAt: todo.dueAt,
+                        id: todo.id,
+                        priority: todo.priority,
+                        title: todo.title,
+                      },
+                    ]
+                  : [],
+              ) ?? undefined,
+            locale: input.locale,
+            overviewWeek: input.overviewWeek,
+            referenceNow: input.referenceNow,
+            sectionIds: input.context.sectionIds,
+            semesters,
+            skipLinks: input.tab === "calendar",
+            user: input.context.user,
+          });
+        })
+      : inactiveStage(null);
+  const linksPromise =
+    input.tab === "links"
+      ? timeDashboardStage("links", stageContext, () =>
+          dashboardLinks.getLinksTabData(input.userId, input.locale),
         )
       : inactiveStage(null);
-    const pendingTodosCountPromise = shouldLoadTodos
-      ? todosPromise.then(
-          (items) => items?.filter((todo) => !todo.completed).length ?? 0,
+  const homeworksPromise =
+    input.tab === "homeworks"
+      ? timeDashboardStage("homeworks", stageContext, () =>
+          dashboardTabs.getHomeworksTabData(input.userId, input.locale, {
+            sectionIds: input.context.sectionIds,
+          }),
         )
-      : undefined;
-    const navStatsCounter = createDashboardStageCounter({
-      dbContext: "rls",
-      dbLabel: "app",
-    });
-    const navStatsPromise = timeDashboardStage(
-      "nav_stats",
-      stageContext,
-      async () =>
-        dashboard.getDashboardNavStats(
-          input.context.user,
-          input.context.subscribedSections,
-          input.referenceNow,
-          pendingTodosCountPromise,
-          await semestersPromise,
-          navStatsCounter,
-        ),
-    );
-    const overviewPromise =
-      input.tab === "overview" || input.tab === "calendar"
-        ? timeDashboardStage("overview", stageContext, async () => {
-            const [semesters, overviewTodos] = await Promise.all([
-              semestersPromise,
-              todosPromise,
-            ]);
-            return dashboard.getDashboardOverviewData(input.userId, {
-              calendarMode: input.tab === "calendar" ? "semester" : "preview",
-              calendarSemesterId: input.calendarSemesterId,
-              calendarTodos:
-                overviewTodos?.flatMap((todo) =>
-                  !todo.completed && todo.dueAt
-                    ? [
-                        {
-                          completed: false,
-                          content: todo.content,
-                          dueAt: todo.dueAt,
-                          id: todo.id,
-                          priority: todo.priority,
-                          title: todo.title,
-                        },
-                      ]
-                    : [],
-                ) ?? undefined,
-              locale: input.locale,
-              overviewWeek: input.overviewWeek,
-              referenceNow: input.referenceNow,
-              sectionIds: input.context.sectionIds,
-              semesters,
-              skipLinks: input.tab === "calendar",
-              user: input.context.user,
-            });
-          })
-        : inactiveStage(null);
-    const linksPromise =
-      input.tab === "links"
-        ? timeDashboardStage("links", stageContext, () =>
-            dashboardLinks.getLinksTabData(input.userId, input.locale),
-          )
-        : inactiveStage(null);
-    const homeworksPromise =
-      input.tab === "homeworks"
-        ? timeDashboardStage("homeworks", stageContext, () =>
-            dashboardTabs.getHomeworksTabData(input.userId, input.locale, {
-              sectionIds: input.context.sectionIds,
-            }),
-          )
-        : inactiveStage(null);
-    const subscriptionsPromise =
-      input.tab === "subscriptions" || input.tab === "exams"
-        ? timeDashboardStage("subscriptions", stageContext, () =>
-            dashboardTabs.getSubscriptionsTabData(input.userId, input.locale, {
-              calendarFeedToken: input.revealCalendarFeed
-                ? input.context.user.calendarFeedToken
-                : undefined,
-              includeExams: input.tab === "exams",
-              sectionIds: input.context.sectionIds,
-            }),
-          )
-        : inactiveStage(null);
-    const calendarSubscriptionUrlPromise =
-      input.tab === "calendar"
-        ? timeDashboardStage("calendar-subscription", stageContext, () =>
-            dashboardTabs.getCalendarSubscriptionUrl(
-              input.userId,
-              input.revealCalendarFeed
-                ? input.context.user.calendarFeedToken
-                : undefined,
-            ),
-          )
-        : inactiveStage(null);
-    const busPromise =
-      input.tab === "bus"
-        ? timeDashboardStage("bus", stageContext, () =>
-            dashboardTabs.getBusTabData(input.userId, input.locale),
-          )
-        : inactiveStage(null);
+      : inactiveStage(null);
+  const subscriptionsPromise =
+    input.tab === "subscriptions" || input.tab === "exams"
+      ? timeDashboardStage("subscriptions", stageContext, () =>
+          dashboardTabs.getSubscriptionsTabData(input.userId, input.locale, {
+            calendarFeedToken: input.revealCalendarFeed
+              ? input.context.user.calendarFeedToken
+              : undefined,
+            includeExams: input.tab === "exams",
+            sectionIds: input.context.sectionIds,
+          }),
+        )
+      : inactiveStage(null);
+  const calendarSubscriptionUrlPromise =
+    input.tab === "calendar"
+      ? timeDashboardStage("calendar-subscription", stageContext, () =>
+          dashboardTabs.getCalendarSubscriptionUrl(
+            input.userId,
+            input.revealCalendarFeed
+              ? input.context.user.calendarFeedToken
+              : undefined,
+          ),
+        )
+      : inactiveStage(null);
+  const busPromise =
+    input.tab === "bus"
+      ? timeDashboardStage("bus", stageContext, () =>
+          dashboardTabs.getBusTabData(input.userId, input.locale),
+        )
+      : inactiveStage(null);
 
-    const [
-      navStats,
-      todos,
-      overview,
-      links,
-      homeworks,
-      subscriptions,
-      calendarSubscriptionUrl,
-      bus,
-    ] = await Promise.all([
-      navStatsPromise,
-      todosPromise,
-      overviewPromise,
-      linksPromise,
-      homeworksPromise,
-      subscriptionsPromise,
-      calendarSubscriptionUrlPromise,
-      busPromise,
-    ]);
+  const [
+    navStats,
+    todos,
+    overview,
+    links,
+    homeworks,
+    subscriptions,
+    calendarSubscriptionUrl,
+    bus,
+  ] = await Promise.all([
+    navStatsPromise,
+    todosPromise,
+    overviewPromise,
+    linksPromise,
+    homeworksPromise,
+    subscriptionsPromise,
+    calendarSubscriptionUrlPromise,
+    busPromise,
+  ]);
 
-    return {
-      bus,
-      calendarSubscriptionUrl,
-      homeworks,
-      links,
-      navStats,
-      overview,
-      subscriptions,
-      todos,
-    };
-  });
+  return {
+    bus,
+    calendarSubscriptionUrl,
+    homeworks,
+    links,
+    navStats,
+    overview,
+    subscriptions,
+    todos,
+  };
 }

--- a/tests/integration/dashboard-page-rls-reuse.test.ts
+++ b/tests/integration/dashboard-page-rls-reuse.test.ts
@@ -6,7 +6,7 @@ import {
   type TestPrismaClient,
 } from "../shared/prisma";
 
-describe("signed dashboard localized RLS context", () => {
+describe("signed dashboard independent RLS contexts", () => {
   let testPrisma: TestPrismaClient;
 
   beforeAll(() => {
@@ -17,7 +17,7 @@ describe("signed dashboard localized RLS context", () => {
     await disconnectTestPrisma(testPrisma);
   });
 
-  it("loads the complete overview through one reusable localized transaction", async () => {
+  it("keeps overview and calendar data semantics across short RLS reads", async () => {
     const subscription =
       await testPrisma.userSectionSubscription.findFirstOrThrow({
         orderBy: { userId: "asc" },

--- a/tests/unit/compact-overview-read-model.test.ts
+++ b/tests/unit/compact-overview-read-model.test.ts
@@ -8,7 +8,6 @@ const {
   loadOverviewTodoBundleMock,
   runCloudflareTraceSpanMock,
   userFindUniqueMock,
-  withLocalizedUserDbContextMock,
   withUserDbContextMock,
 } = vi.hoisted(() => {
   const userFindUnique = vi.fn();
@@ -22,13 +21,6 @@ const {
         callback(),
     ),
     userFindUniqueMock: userFindUnique,
-    withLocalizedUserDbContextMock: vi.fn(
-      async (
-        _locale: string,
-        _userId: string,
-        action: () => Promise<unknown>,
-      ) => action(),
-    ),
     withUserDbContextMock: vi.fn(
       async (
         _userId: string,
@@ -43,7 +35,6 @@ vi.mock("@/lib/adapters/cloudflare-runtime", () => ({
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
-  withLocalizedUserDbContext: withLocalizedUserDbContextMock,
   withUserDbContext: withUserDbContextMock,
 }));
 
@@ -120,12 +111,6 @@ describe("compact workspace overview read model", () => {
     const overview = await getCompactOverview("user-1", { atTime: AT_TIME });
 
     expect(userFindUniqueMock).toHaveBeenCalledOnce();
-    expect(withLocalizedUserDbContextMock).toHaveBeenCalledOnce();
-    expect(withLocalizedUserDbContextMock).toHaveBeenCalledWith(
-      "zh-cn",
-      "user-1",
-      expect.any(Function),
-    );
     expect(userFindUniqueMock).toHaveBeenCalledWith({
       where: { id: "user-1" },
       select: {

--- a/tests/unit/dashboard-page-parallelism.test.ts
+++ b/tests/unit/dashboard-page-parallelism.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../shared/deferred";
+
+type ReadShape = {
+  name: string;
+  sectionCount: number;
+  todoCount: number;
+};
+
+type ReadRecord = {
+  queryCount: number;
+  rowCount: number;
+  stage: "nav_stats" | "todos";
+  transactionId: number;
+  userId: string;
+};
+
+const READ_SHAPES: ReadShape[] = [
+  { name: "small", sectionCount: 2, todoCount: 3 },
+  { name: "large", sectionCount: 64, todoCount: 160 },
+];
+
+const {
+  getDashboardNavStatsMock,
+  getDashboardOverviewDataMock,
+  getDashboardSemestersMock,
+  getTodosTabDataMock,
+  transactionState,
+  withUserDbContextMock,
+} = vi.hoisted(() => {
+  let activeTransaction: { id: number } | undefined;
+  let nextTransactionId = 0;
+  const state = {
+    active: 0,
+    maxActive: 0,
+    reads: [] as ReadRecord[],
+  };
+  const withUserDbContext = vi.fn(
+    async (
+      _userId: string,
+      action: (tx: { id: number }) => Promise<unknown>,
+    ) => {
+      const inheritedTransaction = activeTransaction;
+      if (inheritedTransaction) return action(inheritedTransaction);
+
+      const transaction = { id: ++nextTransactionId };
+      activeTransaction = transaction;
+      state.active += 1;
+      state.maxActive = Math.max(state.maxActive, state.active);
+
+      let result: Promise<unknown>;
+      try {
+        result = action(transaction);
+      } catch (error) {
+        activeTransaction = inheritedTransaction;
+        state.active -= 1;
+        throw error;
+      }
+      activeTransaction = inheritedTransaction;
+      return result.finally(() => {
+        state.active -= 1;
+      });
+    },
+  );
+
+  return {
+    getDashboardNavStatsMock: vi.fn(),
+    getDashboardOverviewDataMock: vi.fn(),
+    getDashboardSemestersMock: vi.fn(),
+    getTodosTabDataMock: vi.fn(),
+    transactionState: state,
+    withUserDbContextMock: withUserDbContext,
+  };
+});
+
+vi.mock("@/features/dashboard/server/dashboard-overview-data", () => ({
+  getDashboardNavStats: getDashboardNavStatsMock,
+  getDashboardOverviewData: getDashboardOverviewDataMock,
+  getDashboardSemesters: getDashboardSemestersMock,
+}));
+
+vi.mock("@/features/dashboard/server/dashboard-tab-data", () => ({
+  getBusTabData: vi.fn(),
+  getCalendarSubscriptionUrl: vi.fn(),
+  getHomeworksTabData: vi.fn(),
+  getSubscriptionsTabData: vi.fn(),
+  getTodosTabData: getTodosTabDataMock,
+}));
+
+vi.mock("@/features/dashboard-links/server/dashboard-link-data", () => ({
+  getLinksTabData: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  withUserDbContext: withUserDbContextMock,
+}));
+
+vi.mock("@/lib/log/app-logger", () => ({ logAppEvent: vi.fn() }));
+
+import { loadSignedDashboardTabData } from "@/features/dashboard/server/dashboard-page-tab-data";
+
+function buildContext(sectionCount: number) {
+  const subscribedSections = Array.from(
+    { length: sectionCount },
+    (_, index) => ({ id: index + 1, semesterId: 1, retiredAt: null }),
+  );
+  return {
+    sectionIds: subscribedSections.map((section) => section.id),
+    subscribedSections,
+    user: {
+      calendarFeedToken: null,
+      id: "user-1",
+      name: "User",
+      username: "user",
+    },
+  };
+}
+
+function loadOverviewTab(sectionCount: number) {
+  return loadSignedDashboardTabData({
+    calendarSemesterId: undefined,
+    context: buildContext(sectionCount),
+    locale: "en-us",
+    referenceNow: new Date("2026-05-22T10:30:00.000Z"),
+    requestId: "dashboard-parallelism-test",
+    tab: "overview",
+    userId: "user-1",
+  });
+}
+
+describe("signed dashboard RLS fan-out benchmark", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    transactionState.active = 0;
+    transactionState.maxActive = 0;
+    transactionState.reads = [];
+    getDashboardSemestersMock.mockResolvedValue([
+      {
+        id: 1,
+        nameCn: "2026春",
+        startDate: new Date("2026-02-01T00:00:00.000Z"),
+        endDate: new Date("2026-07-01T00:00:00.000Z"),
+      },
+    ]);
+    getDashboardOverviewDataMock.mockResolvedValue({});
+  });
+
+  it.each(READ_SHAPES)(
+    "keeps fixed user reads independent for the $name subscription/todo shape",
+    async ({ sectionCount, todoCount }) => {
+      const todoGate = createDeferred<void>();
+      const navGate = createDeferred<void>();
+      const todos = Array.from({ length: todoCount }, (_, index) => ({
+        completed: index % 4 === 0,
+        content: null,
+        createdAt: "2026-05-22T02:30:00.000Z",
+        dueAt: null,
+        id: `todo-${index}`,
+        priority: "medium" as const,
+        title: `Todo ${index}`,
+        updatedAt: "2026-05-22T02:30:00.000Z",
+      }));
+
+      getTodosTabDataMock.mockImplementation(() =>
+        withUserDbContextMock("user-1", async (tx) => {
+          transactionState.reads.push({
+            queryCount: 1,
+            rowCount: todos.length,
+            stage: "todos",
+            transactionId: tx.id,
+            userId: "user-1",
+          });
+          await todoGate.promise;
+          return todos;
+        }),
+      );
+      getDashboardNavStatsMock.mockImplementation(
+        async (
+          _user: unknown,
+          _sections: unknown,
+          _referenceNow: unknown,
+          pendingTodosCount: Promise<number> | undefined,
+        ) =>
+          withUserDbContextMock("user-1", async (tx) => {
+            transactionState.reads.push({
+              queryCount: 1,
+              rowCount: sectionCount,
+              stage: "nav_stats",
+              transactionId: tx.id,
+              userId: "user-1",
+            });
+            await navGate.promise;
+            return {
+              pendingTodosCount: (await pendingTodosCount) ?? 0,
+            };
+          }),
+      );
+
+      const resultPromise = loadOverviewTab(sectionCount);
+      await vi.waitFor(() => {
+        expect(transactionState.reads).toHaveLength(2);
+      });
+
+      // A shared interactive transaction would make both reads observe one
+      // client and this maximum stay at one. Separate user contexts overlap
+      // at the pool boundary while preserving the explicit user ID.
+      expect(transactionState.maxActive).toBe(2);
+      expect(
+        new Set(transactionState.reads.map((read) => read.transactionId)).size,
+      ).toBe(2);
+      expect(transactionState.reads).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            queryCount: 1,
+            rowCount: todoCount,
+            stage: "todos",
+            userId: "user-1",
+          }),
+          expect.objectContaining({
+            queryCount: 1,
+            rowCount: sectionCount,
+            stage: "nav_stats",
+            userId: "user-1",
+          }),
+        ]),
+      );
+
+      todoGate.resolve();
+      navGate.resolve();
+      const result = await resultPromise;
+      expect(result.todos).toHaveLength(todoCount);
+      expect(result.navStats).toEqual({
+        pendingTodosCount: todos.filter((todo) => !todo.completed).length,
+      });
+      expect(getTodosTabDataMock).toHaveBeenCalledOnce();
+      expect(getDashboardNavStatsMock).toHaveBeenCalledOnce();
+      expect(withUserDbContextMock).toHaveBeenCalledTimes(2);
+      expect(transactionState.active).toBe(0);
+    },
+  );
+});

--- a/tests/unit/dashboard-page-rls-reuse.test.ts
+++ b/tests/unit/dashboard-page-rls-reuse.test.ts
@@ -1,17 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
-const {
-  getDashboardUserContextMock,
-  loadSignedDashboardTabDataMock,
-  withLocalizedUserDbContextMock,
-} = vi.hoisted(() => ({
-  getDashboardUserContextMock: vi.fn(),
-  loadSignedDashboardTabDataMock: vi.fn(),
-  withLocalizedUserDbContextMock: vi.fn(
-    async (_locale: string, _userId: string, action: () => Promise<unknown>) =>
-      action(),
-  ),
-}));
+const { getDashboardUserContextMock, loadSignedDashboardTabDataMock } =
+  vi.hoisted(() => ({
+    getDashboardUserContextMock: vi.fn(),
+    loadSignedDashboardTabDataMock: vi.fn(),
+  }));
 
 vi.mock("@/features/dashboard/server/dashboard-overview-data", () => ({
   getDashboardUserContext: getDashboardUserContextMock,
@@ -25,14 +18,10 @@ vi.mock("@/features/dashboard/server/dashboard-page-tab-data", () => ({
   ),
 }));
 
-vi.mock("@/lib/db/prisma", () => ({
-  withLocalizedUserDbContext: withLocalizedUserDbContextMock,
-}));
-
 import { loadSignedDashboardPageData } from "@/features/dashboard/server/dashboard-page-load-signed";
 
-describe("signed dashboard RLS reuse", () => {
-  it("loads user context, nav, and overview inside one localized transaction", async () => {
+describe("signed dashboard RLS boundaries", () => {
+  it("loads the shell context before independent tab read models", async () => {
     const context = {
       sectionIds: [12],
       subscribedSections: [{ id: 12, retiredAt: null, semesterId: 1 }],
@@ -66,12 +55,6 @@ describe("signed dashboard RLS reuse", () => {
       userId: "user-1",
     });
 
-    expect(withLocalizedUserDbContextMock).toHaveBeenCalledOnce();
-    expect(withLocalizedUserDbContextMock).toHaveBeenCalledWith(
-      "en-us",
-      "user-1",
-      expect.any(Function),
-    );
     expect(getDashboardUserContextMock).toHaveBeenCalledOnce();
     expect(loadSignedDashboardTabDataMock).toHaveBeenCalledOnce();
   });

--- a/tests/unit/dashboard-todo-nav-reuse.test.ts
+++ b/tests/unit/dashboard-todo-nav-reuse.test.ts
@@ -76,7 +76,7 @@ function loadTab(tab: string) {
   });
 }
 
-describe("dashboard todo count reuse", () => {
+describe("dashboard todo count reuse and RLS fan-out", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getDashboardOverviewDataMock.mockResolvedValue({});
@@ -120,7 +120,7 @@ describe("dashboard todo count reuse", () => {
         expect(getDashboardNavStatsMock).toHaveBeenCalledOnce();
       });
       expect(getDashboardOverviewDataMock).not.toHaveBeenCalled();
-      expect(withUserDbContextMock).toHaveBeenCalledOnce();
+      expect(withUserDbContextMock).not.toHaveBeenCalled();
 
       resolveTodos([
         { completed: false },
@@ -162,13 +162,13 @@ describe("dashboard todo count reuse", () => {
     );
   });
 
-  it("shares one RLS transaction and semester snapshot across todo and nav reads", async () => {
+  it("shares one semester snapshot while todo and nav reads stay independent", async () => {
     getTodosTabDataMock.mockResolvedValue([{ completed: false }]);
     getDashboardNavStatsMock.mockResolvedValue({ pendingTodosCount: 1 });
 
     await loadTab("overview");
 
-    expect(withUserDbContextMock).toHaveBeenCalledOnce();
+    expect(withUserDbContextMock).not.toHaveBeenCalled();
     expect(getDashboardSemestersMock).toHaveBeenCalledOnce();
     const semesters = await getDashboardSemestersMock.mock.results[0]?.value;
     expect(getDashboardNavStatsMock).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- Closes #934.
- Removes the signed workspace page's outer interactive RLS transaction so fixed read-model fan-out can use bounded pool connections.
- Keeps each owner-scoped read in its own `withUserDbContext` transaction and keeps explicit section IDs/user snapshots for public catalog reads.
- Removes the same shared transaction from the compact overview aggregate.
- Preserves existing stage logs/counters and adds a production-shaped small/large subscription+todo fan-out regression benchmark with query-count and payload assertions.

## Root cause

The page loader opened one localized RLS transaction around the complete signed-in load. `withUserDbContext` reuses that transaction through AsyncLocalStorage, so the nested read models' `Promise.all` calls still shared one Prisma transaction client. PostgreSQL executes those concurrent operations serially on that connection, turning fixed fan-out into a queue and inflating the page tail.

## Design/security

The shell identity/subscription scope is read in one short RLS transaction. The tab orchestrator is now context-free. Every personal read model establishes its own user-scoped RLS transaction; public localized reads remain outside RLS and use the already validated section IDs supplied by the shell context. No auth cache, cross-request reuse, fallback, compatibility layer, or response caching was added.

The compact overview follows the same boundary: owner data is loaded in its existing RLS contexts, while explicit scoped catalog reads can overlap on the bounded request pool. Payload shaping and stage telemetry are unchanged.

## Validation

- `bunx vitest run --coverage` — 383 files / 2,397 tests passed.
- Relevant dashboard/read-model unit suite — 10 files / 34 tests passed.
- `bunx vitest run --config vitest.integration.config.ts tests/integration/dashboard-page-rls-reuse.test.ts` — passed.
- `bunx tsc --noEmit -p tsconfig.typecheck.json` — passed.
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json` — passed.
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json` — passed.
- `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors; 5 pre-existing warnings in `SectionDetailMainContent.svelte`.
- `bun run openapi:check` — passed.
- `bun run build` — passed; same 5 pre-existing Svelte warnings.
- `bunx wrangler types --include-runtime=false --check` — passed.
- `git diff --check` — passed.

Post-deploy, compare the existing `dashboard.load.stage`/finish telemetry and the seven-day p50/p95/p99 against the #934 baseline; this branch does not deploy production.

<!-- project-relationship:start -->
## Project relationship

Part of #601.
<!-- project-relationship:end -->